### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ node_js:
   - 'node'
   - '10'
   - '8'
-  - '6'
 script:
 # Unfortunately flow falls over when a dep exists in peer deps and others. :(
 # @see https://github.com/flowtype/flow-typed/issues/528

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ cache:
   directories:
     - node_modules
 node_js:
-- '8'
+  - 'node'
+  - '10'
+  - '8'
+  - '6'
 script:
 # Unfortunately flow falls over when a dep exists in peer deps and others. :(
 # @see https://github.com/flowtype/flow-typed/issues/528
 #- yarn run flow:defs
-- npm run test
+- yarn run test
 after_success:
 # Deploy code coverage report to codecov.io
-- npm run test:coverage:deploy
+- yarn run test:coverage:deploy


### PR DESCRIPTION
Node.js 6, 8 and 10 are the current LTS branches and 11 is stable. See https://github.com/nodejs/Release/blob/master/README.md

We should test them all to catch any issues.