### PR TITLE
Adds reducer helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ function TodoList() {
     - [createStore(model, config)](#createstoremodel-config)
     - [action](#action)
     - [effect(action)](#effectaction)
+    - [reducer(fn)](#reducerfn)
     - [select(selector)](#selectselector)
     - [StoreProvider](#storeprovider)
     - [useStore(mapState, externals)](#usestoremapstate-externals)
@@ -677,6 +678,54 @@ const store = createStore(
 );
 
 store.dispatch.doSomething()
+```
+
+### reducer(fn)
+
+Declares a section of state that is derived via the given selector function. This was specifically added to allow for integrations with existing libraries, or legacy Redux code.
+
+Some 3rd party libraries, for example [`connected-react-router`](https://github.com/supasate/connected-react-router), require you to attach a reducer that they provide to your state. This helper will you achieve this.
+
+#### Arguments
+
+  - fn (Function, required)
+
+    The reducer function. It receives the following arguments.
+
+    - `state` (Object, required)
+
+      The current value of the property that the reducer was attached to.
+
+    - `action` (Object, required)
+
+      The action object, typically with the following shape.
+
+      - `type` (string, required)
+
+        The name of the action.
+
+      - `payload` (any)
+
+        Any payload that was provided to the action.
+
+#### Example
+
+```javascript
+import { createStore, reducer } from 'easy-peasy';
+
+const store = createStore({
+  counter: reducer((state = 1, action) => {
+    switch (action.type) {
+      case 'INCREMENT': state + 1;
+      default: return state;
+    }
+  })
+});
+
+store.dispatch({ type: 'INCREMENT' });
+
+store.getState().counter;
+// 2
 ```
 
 ### select(selector)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.5.0",
+  "version": "1.6.0-alpha.0",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -945,6 +945,9 @@ describe('reducer', () => {
       },
     })
 
+    // assert
+    expect(store.getState().counter).toEqual(1)
+
     // act
     store.dispatch({ type: 'INCREMENT' })
 

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -937,13 +937,24 @@ describe('reducer', () => {
         }
         return state
       }),
+      foo: {
+        bar: 'baz',
+        update: state => {
+          state.bar = 'bob'
+        },
+      },
     })
 
     // act
     store.dispatch({ type: 'INCREMENT' })
 
     // assert
-    expect(store.getState().counter).toBe(2)
+    expect(store.getState()).toEqual({
+      counter: 2,
+      foo: {
+        bar: 'baz',
+      },
+    })
   })
 
   it('nested', () => {
@@ -963,7 +974,11 @@ describe('reducer', () => {
     store.dispatch({ type: 'INCREMENT' })
 
     // assert
-    expect(store.getState().stuff.counter).toBe(2)
+    expect(store.getState()).toEqual({
+      stuff: {
+        counter: 2,
+      },
+    })
   })
 
   it('with selector', () => {
@@ -987,6 +1002,9 @@ describe('reducer', () => {
     })
 
     // assert
-    expect(store.getState().totalPrice).toBe(10)
+    expect(store.getState()).toEqual({
+      products: [{ name: 'Boots', price: 10 }],
+      totalPrice: 10,
+    })
   })
 })

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -9,6 +9,7 @@ import {
   StoreProvider,
   createStore,
   effect,
+  reducer,
   select,
   useStore,
   useAction,
@@ -923,5 +924,69 @@ describe('dependency injection', () => {
 
     // assert
     expect(injection).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('reducer', () => {
+  it('basic', () => {
+    // arrange
+    const store = createStore({
+      counter: reducer((state = 1, action) => {
+        if (action.type === 'INCREMENT') {
+          return state + 1
+        }
+        return state
+      }),
+    })
+
+    // act
+    store.dispatch({ type: 'INCREMENT' })
+
+    // assert
+    expect(store.getState().counter).toBe(2)
+  })
+
+  it('nested', () => {
+    // arrange
+    const store = createStore({
+      stuff: {
+        counter: reducer((state = 1, action) => {
+          if (action.type === 'INCREMENT') {
+            return state + 1
+          }
+          return state
+        }),
+      },
+    })
+
+    // act
+    store.dispatch({ type: 'INCREMENT' })
+
+    // assert
+    expect(store.getState().stuff.counter).toBe(2)
+  })
+
+  it('with selector', () => {
+    // arrange
+    const store = createStore({
+      products: reducer((state = [], { type, payload }) => {
+        if (type === 'ADD_PRODUCT') {
+          return [...state, payload]
+        }
+        return state
+      }),
+      totalPrice: select(state =>
+        state.products.reduce((acc, cur) => acc + cur.price, 0),
+      ),
+    })
+
+    // act
+    store.dispatch({
+      type: 'ADD_PRODUCT',
+      payload: { name: 'Boots', price: 10 },
+    })
+
+    // assert
+    expect(store.getState().totalPrice).toBe(10)
   })
 })

--- a/src/easy-peasy.js
+++ b/src/easy-peasy.js
@@ -150,8 +150,6 @@ export const createStore = (model, options = {}) => {
 
   extract(definition, [])
 
-  console.log(customReducers)
-
   const createReducers = (current, path) => {
     const actionReducersAtPath = Object.keys(current).reduce((acc, key) => {
       const value = current[key]

--- a/src/easy-peasy.js
+++ b/src/easy-peasy.js
@@ -207,9 +207,8 @@ export const createStore = (model, options = {}) => {
             const stateAfterActions = reducerForActions(state, action)
             return produce(stateAfterActions, draft => {
               customReducers.forEach(({ path: p, reducer: red }) => {
-                const target = get(p, draft)
-                const result = red(target, action)
-                set(p, draft, result)
+                const current = get(p, draft)
+                set(p, draft, red(current, action))
               })
             })
           }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,13 @@
-import { createStore, effect, select } from './easy-peasy'
+import { createStore, effect, reducer, select } from './easy-peasy'
 import { useStore, useAction } from './hooks'
 import StoreProvider from './provider'
 
-export { createStore, effect, select, useStore, useAction, StoreProvider }
+export {
+  createStore,
+  effect,
+  reducer,
+  select,
+  StoreProvider,
+  useAction,
+  useStore,
+}


### PR DESCRIPTION
Released as 1.6.0-alpha.1

Provides the ability to define a custom "standard" reducer:

```javascript
import { createStore, reducer } from 'easy-peasy';

const store = createStore({
  counter: reducer((state = 1, action) => {
    switch (action.type) {
      case 'INCREMENT': state + 1;  	
      default: return state;
    }
  })
});

store.dispatch({ type: 'INCREMENT' });

store.getState().counter;
// 2
```

Closes #25 