### PR TITLE
Fix warning of memoized-one

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "immer": "^1.7.4",
-    "memoize-one": "^4.0.3",
+    "memoize-one": "^5.0.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "shallowequal": "^1.1.0"


### PR DESCRIPTION
Warning:
```
warning easy-peasy > memoize-one@4.1.0: 
New custom equality api does not play well with all equality helpers. 
Please use v5.x
```