### PR TITLE
TypeScript definitions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     "@babel/preset-env",
-    "@babel/preset-react"
+    "@babel/preset-react",
+    "@babel/preset-typescript"
   ],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,79 +50,73 @@ type EffectMeta = {
  * This type recursively filters a model down to the properties which
  * represent actions
  */
-export type Actions<TModel extends Object> = {
+export type Actions<Model extends Object> = {
   [P in keyof (Omit<
-    TModel,
-    KeysOfType<
-      Pick<TModel, KeysOfType<TModel, Object>>,
-      NaturalState | UtilTypes
-    >
-  >)]: Actions<TModel[P]>
+    Model,
+    KeysOfType<Pick<Model, KeysOfType<Model, Object>>, NaturalState | UtilTypes>
+  >)]: Actions<Model[P]>
 } &
   {
-    [P in keyof Pick<TModel, KeysOfType<TModel, ActionTypes>>]: Param1<
-      TModel[P]
+    [P in keyof Pick<Model, KeysOfType<Model, ActionTypes>>]: Param1<
+      Model[P]
     > extends void
-      ? () => UnsafeReturnType<Param1<TModel[P]>>
-      : (payload: Param1<TModel[P]>) => UnsafeReturnType<Param1<TModel[P]>>
+      ? () => UnsafeReturnType<Param1<Model[P]>>
+      : (payload: Param1<Model[P]>) => UnsafeReturnType<Param1<Model[P]>>
   }
 
 /**
  * This type recursively filters a model down to the properties which
  * represent state - i.e. no actions/selectors etc.
  */
-export type State<TModel extends Object> = {
+export type State<Model extends Object> = {
   [P in keyof (Omit<
-    TModel,
-    KeysOfType<
-      Pick<TModel, KeysOfType<TModel, Object>>,
-      NaturalState | UtilTypes
-    >
-  >)]: State<TModel[P]>
+    Model,
+    KeysOfType<Pick<Model, KeysOfType<Model, Object>>, NaturalState | UtilTypes>
+  >)]: State<Model[P]>
 } &
-  { [P in keyof Pick<TModel, KeysOfType<TModel, NaturalState>>]: TModel[P] } &
+  { [P in keyof Pick<Model, KeysOfType<Model, NaturalState>>]: Model[P] } &
   {
     readonly [P in keyof Pick<
-      TModel,
-      KeysOfType<TModel, Select<any, any>>
-    >]: UnsafeReturnType<TModel[P]>
+      Model,
+      KeysOfType<Model, Select<any, any>>
+    >]: UnsafeReturnType<Model[P]>
   } &
   {
     readonly [P in keyof Pick<
-      TModel,
-      KeysOfType<TModel, Reducer<any, any>>
-    >]: UnsafeReturnType<TModel[P]>
+      Model,
+      KeysOfType<Model, Reducer<any, any>>
+    >]: UnsafeReturnType<Model[P]>
   }
 
 /**
  * Configuration for the createStore
  */
 export interface EasyPeasyConfig<
-  TInitialState extends Object = {},
-  TInjections = void
+  InitialState extends Object = {},
+  Injections = void
 > {
   compose?: typeof compose
   devTools?: boolean
-  initialState?: TInitialState
-  injections?: TInjections
+  initialState?: InitialState
+  injections?: Injections
   middlewares?: Array<Middleware<any, any, any>>
   reducerEnhancer?: (reducer: Reducer<any, any>) => Reducer<any, any>
 }
 
 export type Reducer<
-  TState = any,
-  TAction extends ReduxAction = AnyAction
-> = ReduxReducer<TState>
+  State = any,
+  Action extends ReduxAction = AnyAction
+> = ReduxReducer<State>
 
 export type Dispatch<
-  TModel,
-  TAction extends ReduxAction = ReduxAction<any>
-> = Actions<TModel> & ReduxDispatch<TAction>
+  Model,
+  Action extends ReduxAction = ReduxAction<any>
+> = Actions<Model> & ReduxDispatch<Action>
 
-export type Store<TModel> = Overwrite<
-  ReduxStore<State<TModel>>,
+export type Store<Model> = Overwrite<
+  ReduxStore<State<Model>>,
   {
-    dispatch: Dispatch<TModel>
+    dispatch: Dispatch<Model>
   }
 >
 
@@ -139,17 +133,17 @@ export type Store<TModel> = Overwrite<
  * }
  */
 export type Effect<
-  TModel extends Object = {},
-  TPayload = void,
-  TResult = void,
-  TInjections = void
+  Model extends Object = {},
+  Payload = void,
+  Result = void,
+  Injections = void
 > = (
-  dispatch: Actions<TModel>,
-  payload: TPayload,
-  getState: () => State<TModel>,
-  injections: TInjections,
+  dispatch: Actions<Model>,
+  payload: Payload,
+  getState: () => State<Model>,
+  injections: Injections,
   meta: EffectMeta,
-) => void | Promise<TResult> | TResult
+) => void | Promise<Result> | Result
 
 /**
  * An action type.
@@ -163,10 +157,10 @@ export type Effect<
  *   increment: Action<Model>;
  * }
  */
-export type Action<TModel extends Object = {}, TPayload = void> = (
-  state: State<TModel>,
-  payload: TPayload,
-) => void | State<TModel>
+export type Action<Model extends Object = {}, Payload = void> = (
+  state: State<Model>,
+  payload: Payload,
+) => void | State<Model>
 
 /**
  * A select type.
@@ -180,10 +174,10 @@ export type Action<TModel extends Object = {}, TPayload = void> = (
  *   totalPrice: Select<Model, number>;
  * }
  */
-export type Select<TModel extends Object = {}, TResult = void> = (
-  state: State<TModel>,
+export type Select<Model extends Object = {}, Result = void> = (
+  state: State<Model>,
   dependencies?: Array<Select<any, any>>,
-) => TResult
+) => Result
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#effectaction
@@ -198,13 +192,13 @@ export type Select<TModel extends Object = {}, TResult = void> = (
  * })
  */
 export function effect<
-  TModel extends Object = {},
-  TPayload = void,
-  TResult = void,
-  TInjections = void
+  Model extends Object = {},
+  Payload = void,
+  Result = void,
+  Injections = void
 >(
-  effect: Effect<TModel, TPayload, TResult, TInjections>,
-): Effect<TModel, TPayload, TResult, TInjections>
+  effect: Effect<Model, Payload, Result, Injections>,
+): Effect<Model, Payload, Result, Injections>
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#selectselector
@@ -217,10 +211,10 @@ export function effect<
  *   state.products.reduce((acc, cur) => acc + cur.price, 0)
  * );
  */
-export function select<TModel extends Object = {}, TResult = void>(
-  select: Select<TModel, TResult>,
+export function select<Model extends Object = {}, Result = void>(
+  select: Select<Model, Result>,
   dependencies?: Array<Select<any, any>>,
-): Select<TModel, TResult>
+): Select<Model, Result>
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#reducerfn
@@ -236,9 +230,9 @@ export function select<TModel extends Object = {}, TResult = void>(
  *   }
  * });
  */
-export function reducer<TState extends Object = {}>(
-  state: Reducer<TState>,
-): Reducer<TState>
+export function reducer<State extends Object = {}>(
+  state: Reducer<State>,
+): Reducer<State>
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#createstoremodel-config
@@ -259,10 +253,10 @@ export function reducer<TState extends Object = {}>(
  *   }
  * })
  */
-export function createStore<TModel extends Object = {}>(
-  model: TModel,
+export function createStore<Model extends Object = {}>(
+  model: Model,
   config?: EasyPeasyConfig,
-): Store<TModel>
+): Store<Model>
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#usestoremapstate-externals
@@ -271,17 +265,17 @@ export function createStore<TModel extends Object = {}>(
  *
  * import { useStore } from 'easy-peasy';
  *
- * const todos = useStore<Model, Array<Todo>>(state => state.todos.items);
+ * const todos = useStore((state: State<Model>) => state.todos.items);
  *
- * const { totalPrice, netPrice } = useStore<Model, { totalPrice: number, netPrice: number }>(state => ({
+ * const { totalPrice, netPrice } = useStore((state: State<Model>) => ({
  *   totalPrice: state.basket.totalPrice,
  *   netPrice: state.basket.netPrice
  * }));
  */
-export function useStore<TModel extends Object = {}, TReturn = any>(
-  mapState: (state: State<TModel>) => TReturn,
+export function useStore<Model extends Object = {}, Result = any>(
+  mapState: (state: State<Model>) => Result,
   dependencies?: Array<any>,
-): TReturn
+): Result
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#useactionmapaction
@@ -290,15 +284,15 @@ export function useStore<TModel extends Object = {}, TReturn = any>(
  *
  * import { useAction } from 'easy-peasy';
  *
- * const addTodo = useAction<Model, Todo>(dispatch => dispatch.todos.add);
+ * const addTodo = useAction((dispatch: Dispatch<Todo>) => dispatch.todos.add);
  *
  * addTodo({ id: 1, text: 'foo' });
  */
 export function useAction<
-  TModel extends Object = {},
-  TPayload = any,
-  TResult = any
->(mapAction: (actions: Dispatch<TModel>) => TResult): TResult
+  Model extends Object = {},
+  Payload = any,
+  Result = any
+>(mapAction: (actions: Dispatch<Model>) => Result): Result
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#storeprovider
@@ -313,6 +307,6 @@ export function useAction<
  *   </StoreProvider>
  * );
  */
-export class StoreProvider<TModel = any> extends Component<{
-  store: Store<TModel>
+export class StoreProvider<Model = any> extends Component<{
+  store: Store<Model>
 }> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,7 +157,7 @@ export type Effect<
  *   increment: Action<Model>;
  * }
  */
-export type Action<Model extends Object = {}, Payload = void> = (
+export type Action<Model extends Object = {}, Payload = any> = (
   state: State<Model>,
   payload: Payload,
 ) => void | State<Model>
@@ -174,7 +174,7 @@ export type Action<Model extends Object = {}, Payload = void> = (
  *   totalPrice: Select<Model, number>;
  * }
  */
-export type Select<Model extends Object = {}, Result = void> = (
+export type Select<Model extends Object = {}, Result = any> = (
   state: State<Model>,
   dependencies?: Array<Select<any, any>>,
 ) => Result
@@ -193,9 +193,9 @@ export type Select<Model extends Object = {}, Result = void> = (
  */
 export function effect<
   Model extends Object = {},
-  Payload = void,
-  Result = void,
-  Injections = void
+  Payload = any,
+  Result = any,
+  Injections = any
 >(
   effect: Effect<Model, Payload, Result, Injections>,
 ): Effect<Model, Payload, Result, Injections>
@@ -211,7 +211,7 @@ export function effect<
  *   state.products.reduce((acc, cur) => acc + cur.price, 0)
  * );
  */
-export function select<Model extends Object = {}, Result = void>(
+export function select<Model extends Object = {}, Result = any>(
   select: Select<Model, Result>,
   dependencies?: Array<Select<any, any>>,
 ): Select<Model, Result>

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,10 +41,6 @@ type UtilTypes =
   | Effect<any, any, any, any>
   | Function
 
-interface ActionCreator<TPayload = any, TResult = any> {
-  (payload: TPayload): TResult
-}
-
 type EffectMeta = {
   path: string[]
   parent: string[]
@@ -64,10 +60,11 @@ export type Actions<TModel extends Object> = {
   >)]: Actions<TModel[P]>
 } &
   {
-    [P in keyof Pick<TModel, KeysOfType<TModel, ActionTypes>>]: ActionCreator<
-      Param1<TModel[P]>,
-      UnsafeReturnType<Param1<TModel[P]>>
-    >
+    [P in keyof Pick<TModel, KeysOfType<TModel, ActionTypes>>]: Param1<
+      TModel[P]
+    > extends void
+      ? () => UnsafeReturnType<Param1<TModel[P]>>
+      : (payload: Param1<TModel[P]>) => UnsafeReturnType<Param1<TModel[P]>>
   }
 
 /**
@@ -299,11 +296,9 @@ export function useStore<TModel extends Object = {}, TReturn = any>(
  */
 export function useAction<
   TModel extends Object = {},
-  TPayload = void,
+  TPayload = any,
   TResult = any
->(
-  mapAction: (actions: Dispatch<TModel>) => ActionCreator<TPayload, TResult>,
-): ActionCreator<TPayload, TResult>
+>(mapAction: (actions: Dispatch<TModel>) => TResult): TResult
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#storeprovider

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,14 @@ export type Actions<Model extends Object> = {
     [P in keyof Pick<Model, KeysOfType<Model, ActionTypes>>]: Param1<
       Model[P]
     > extends void
-      ? () => UnsafeReturnType<Model[P]>
-      : (payload: Param1<Model[P]>) => UnsafeReturnType<Model[P]>
+      ? () => UnsafeReturnType<Model[P]> extends Promise<any>
+          ? UnsafeReturnType<Model[P]>
+          : Promise<UnsafeReturnType<Model[P]>>
+      : (
+          payload: Param1<Model[P]>,
+        ) => UnsafeReturnType<Model[P]> extends Promise<any>
+          ? UnsafeReturnType<Model[P]>
+          : Promise<UnsafeReturnType<Model[P]>>
   }
 
 /**
@@ -135,15 +141,15 @@ export type Store<Model> = Overwrite<
 export type Effect<
   Model extends Object = {},
   Payload = void,
-  Result = void,
-  Injections = void
+  Injections = void,
+  Result = void
 > = (
   dispatch: Actions<Model>,
   payload: Payload,
   getState: () => State<Model>,
   injections: Injections,
   meta: EffectMeta,
-) => Promise<Result>
+) => Result
 
 /**
  * An action type.

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,8 @@ export type Actions<Model extends Object> = {
     [P in keyof Pick<Model, KeysOfType<Model, ActionTypes>>]: Param1<
       Model[P]
     > extends void
-      ? () => UnsafeReturnType<Param1<Model[P]>>
-      : (payload: Param1<Model[P]>) => UnsafeReturnType<Param1<Model[P]>>
+      ? () => UnsafeReturnType<Model[P]>
+      : (payload: Param1<Model[P]>) => UnsafeReturnType<Model[P]>
   }
 
 /**
@@ -143,7 +143,7 @@ export type Effect<
   getState: () => State<Model>,
   injections: Injections,
   meta: EffectMeta,
-) => void | Promise<Result> | Result
+) => Result
 
 /**
  * An action type.

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ export function useAction<
   TPayload = void,
   TResult = any
 >(
-  mapAction: (actions: Actions<TModel>) => ActionCreator<TPayload, TResult>,
+  mapAction: (actions: Dispatch<TModel>) => ActionCreator<TPayload, TResult>,
 ): ActionCreator<TPayload, TResult>
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -290,7 +290,6 @@ export function useStore<Model extends Object = {}, Result = any>(
  */
 export function useAction<
   Model extends Object = {},
-  Payload = any,
   Result = any
 >(mapAction: (actions: Dispatch<Model>) => Result): Result
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,8 +45,6 @@ interface ActionCreator<TPayload = any, TResult = any> {
   (payload: TPayload): TResult
 }
 
-type UseStore<TState = any, TReturn = any> = (state: TState) => TReturn
-
 type EffectMeta = {
   path: string[]
   parent: string[]
@@ -284,7 +282,7 @@ export function createStore<TModel extends Object = {}>(
  * }));
  */
 export function useStore<TModel extends Object = {}, TReturn = any>(
-  mapState: UseStore<State<TModel>, TReturn>,
+  mapState: (state: State<TModel>) => TReturn,
   dependencies?: Array<any>,
 ): TReturn
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,310 @@
+import { Component } from 'react'
+import { KeysOfType, Omit, Overwrite } from 'typelevel-ts'
+import { Param1 } from 'type-zoo'
+import {
+  compose,
+  AnyAction,
+  Action as ReduxAction,
+  Dispatch as ReduxDispatch,
+  Reducer as ReduxReducer,
+  Store as ReduxStore,
+  Middleware,
+} from 'redux'
+
+/**
+ * The standard ReturnType helper of TypeScript doesn't handle generic type
+ * aliases very well. This workaround type does.
+ * https://github.com/Microsoft/TypeScript/issues/26856 
+ */
+type UnsafeReturnType<T> = T extends (...args: any[]) => infer R ? R : any
+
+/**
+ * The types that represent "natural", single level state values in or store. 
+ * i.e. not actions or objects.
+ */
+type NaturalState =
+  | Array<any>
+  | boolean
+  | Date
+  | null
+  | number
+  | RegExp
+  | string
+  | undefined
+
+type ActionTypes = Action<any, any> | Effect<any, any, any, any>
+
+type UtilTypes =
+  | Select<any, any>
+  | Reducer<any>
+  | Action<any, any>
+  | Effect<any, any, any, any>
+  | Function
+
+interface ActionCreator<TPayload = any, TResult = any> {
+  (payload: TPayload): TResult
+}
+
+/**
+ * This type recursively filters a model down to the properties which 
+ * represent actions
+ */
+type Actions<U extends Object> = {
+  [P in keyof (Omit<
+    U,
+    KeysOfType<Pick<U, KeysOfType<U, Object>>, NaturalState | UtilTypes>
+  >)]: Actions<U[P]>
+} &
+  {
+    [P in keyof Pick<U, KeysOfType<U, ActionTypes>>]: ActionCreator<
+      Param1<U[P]>,
+      UnsafeReturnType<Param1<U[P]>>
+    >
+  }
+
+/**
+ * This type recursively filters a model down to the properties which 
+ * represent state - i.e. no actions/selectors etc.
+ */
+type State<U extends Object> = {
+  [P in keyof (Omit<
+    U,
+    KeysOfType<Pick<U, KeysOfType<U, Object>>, NaturalState | UtilTypes>
+  >)]: State<U[P]>
+} &
+  { [P in keyof Pick<U, KeysOfType<U, NaturalState>>]: U[P] } &
+  {
+    [P in keyof Pick<U, KeysOfType<U, Select<any, any>>>]: UnsafeReturnType<
+      U[P]
+    >
+  }
+
+type UseStore<TState = any, TReturn = any> = (state: TState) => TReturn
+
+type EffectMeta = {
+  path: string[]
+  parent: string[]
+}
+
+
+/**
+ * Configuration for the createStore 
+ */
+export interface EasyPeasyConfig<
+  TInitialState extends Object = {},
+  TInjections = void
+> {
+  compose?: typeof compose
+  devTools?: boolean
+  initialState?: TInitialState
+  injections?: TInjections
+  middlewares?: Array<Middleware<any, any, any>>
+  reducerEnhancer?: (reducer: Reducer<any, any>) => Reducer<any, any>
+}
+
+export type Reducer<
+  TState = any,
+  TAction extends ReduxAction = AnyAction
+> = ReduxReducer<TState>
+
+export type Dispatch<TModel, A extends ReduxAction = ReduxAction<any>> = Actions<TModel> & ReduxDispatch<A>;
+
+export type Store<TModel> = Overwrite<
+  ReduxStore<State<TModel>>,
+  {
+    dispatch: Dispatch<TModel>
+  }
+>
+
+/**
+ * An effect action type.
+ *
+ * @example
+ * 
+ * import { Effect } from 'easy-peasy';
+ *
+ * interface Model {
+ *   todos: Array<string>;
+ *   addTodo: Effect<Model, string>;
+ * }
+ */
+export type Effect<
+  TModel extends Object = {},
+  TPayload = void,
+  TResult = void,
+  TInjections = void
+> = (
+  dispatch: Actions<TModel>,
+  payload: TPayload,
+  getState: () => State<TModel>,
+  injections: TInjections,
+  meta: EffectMeta,
+) => void | Promise<TResult> | TResult
+
+/**
+ * An action type.
+ *
+ * @example
+ * 
+ * import { Action } from 'easy-peasy';
+ *
+ * interface Model {
+ *   count: number;
+ *   increment: Action<Model>;
+ * }
+ */
+export type Action<TModel extends Object = {}, UPayload = void> = (
+  state: State<TModel>,
+  payload: UPayload,
+) => void | State<TModel>
+
+/**
+ * A select type.
+ *
+ * @example
+ * 
+ * import { Select } from 'easy-peasy';
+ *
+ * interface Model {
+ *   products: Array<Product>;
+ *   totalPrice: Select<Model, number>;
+ * }
+ */
+export type Select<TModel extends Object = {}, UResult = void> = (
+  state: State<TModel>,
+  dependencies?: Array<Select<any, any>>,
+) => UResult
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#effectaction
+ * 
+ * @example
+ * 
+ * import { effect } from 'easy-peasy';
+ * 
+ * const login = effect<Model, Credentials>(async (dispatch, payload) => {
+ *   const user = await loginService(payload)
+ *   dispatch.session.loginSucceeded(user)
+ * })
+ */
+export function effect<
+  TModel extends Object = {},
+  UPayload = void,
+  UResult = void,
+  UInjections = void
+>(
+  effect: Effect<TModel, UPayload, UResult, UInjections>,
+): Effect<TModel, UPayload, UResult, UInjections>
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#selectselector
+ *
+ * @example
+ * 
+ * import { select } from 'easy-peasy';
+ *
+ * const totalPrice = select<ShoppingBasketModel, number>(state =>
+ *   state.products.reduce((acc, cur) => acc + cur.price, 0)
+ * );
+ */
+export function select<TModel extends Object = {}, UResult = void>(
+  select: Select<TModel, UResult>,
+  dependencies?: Array<Select<any, any>>,
+): Select<TModel, UResult>
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#reducerfn
+ *
+ * @example
+ *
+ * import { reducer } from 'easy-peasy';
+ *
+ * const counter = reducer<number>((state = 1, action) => {
+ *   switch (action.type) {
+ *     case 'INCREMENT': return state + 1;
+ *     default: return state;
+ *   }
+ * });
+ */
+export function reducer<TState extends Object = {}>(
+  state: Reducer<TState>,
+): Reducer<TState>
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#createstoremodel-config
+ *
+ * @example
+ * 
+ * import { createStore } from 'easy-peasy';
+ *
+ * interface Model {
+ *   todos: {
+ *     items: Array<string>;
+ *   }
+ * }
+ *
+ * const store = createStore<Model>({
+ *   todos: {
+ *     items: [],
+ *   }
+ * })
+ */
+export function createStore<TModel extends Object = {}>(
+  model: TModel,
+  config?: EasyPeasyConfig,
+): Store<TModel>
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#usestoremapstate-externals
+ *
+ * @example
+ * 
+ * import { useStore } from 'easy-peasy';
+ *
+ * const todos = useStore<Model, Array<Todo>>(state => state.todos.items);
+ *
+ * const { totalPrice, netPrice } = useStore<Model, { totalPrice: number, netPrice: number }>(state => ({
+ *   totalPrice: state.basket.totalPrice,
+ *   netPrice: state.basket.netPrice
+ * }));
+ */
+export function useStore<TModel extends Object = {}, TReturn = any>(
+  mapState: UseStore<State<TModel>, TReturn>,
+  dependencies?: Array<any>,
+): TReturn
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#useactionmapaction
+ *
+ * @example
+ * 
+ * import { useAction } from 'easy-peasy';
+ *
+ * const addTodo = useAction<Model, Todo>(dispatch => dispatch.todos.add);
+ *
+ * addTodo({ id: 1, text: 'foo' });
+ */
+export function useAction<
+  TModel extends Object = {},
+  TPayload = void,
+  TResult = any
+>(
+  mapAction: (actions: Actions<TModel>) => ActionCreator<TPayload, TResult>,
+): ActionCreator<TPayload, TResult>
+
+/**
+ * https://github.com/ctrlplusb/easy-peasy#storeprovider
+ *
+ * @example
+ * 
+ * import { StoreProvider } from 'easy-peasy';
+ *
+ * ReactDOM.render(
+ *   <StoreProvider store={store}>
+ *     <App />
+ *   </StoreProvider>
+ * );
+ */
+export class StoreProvider<TModel = any> extends Component<{
+  store: Store<TModel>
+}> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,12 +14,12 @@ import {
 /**
  * The standard ReturnType helper of TypeScript doesn't handle generic type
  * aliases very well. This workaround type does.
- * https://github.com/Microsoft/TypeScript/issues/26856 
+ * https://github.com/Microsoft/TypeScript/issues/26856
  */
 type UnsafeReturnType<T> = T extends (...args: any[]) => infer R ? R : any
 
 /**
- * The types that represent "natural", single level state values in or store. 
+ * The types that represent "natural", single level state values in or store.
  * i.e. not actions or objects.
  */
 type NaturalState =
@@ -46,7 +46,7 @@ interface ActionCreator<TPayload = any, TResult = any> {
 }
 
 /**
- * This type recursively filters a model down to the properties which 
+ * This type recursively filters a model down to the properties which
  * represent actions
  */
 type Actions<U extends Object> = {
@@ -63,7 +63,7 @@ type Actions<U extends Object> = {
   }
 
 /**
- * This type recursively filters a model down to the properties which 
+ * This type recursively filters a model down to the properties which
  * represent state - i.e. no actions/selectors etc.
  */
 type State<U extends Object> = {
@@ -74,9 +74,16 @@ type State<U extends Object> = {
 } &
   { [P in keyof Pick<U, KeysOfType<U, NaturalState>>]: U[P] } &
   {
-    [P in keyof Pick<U, KeysOfType<U, Select<any, any>>>]: UnsafeReturnType<
-      U[P]
-    >
+    readonly [P in keyof Pick<
+      U,
+      KeysOfType<U, Select<any, any>>
+    >]: UnsafeReturnType<U[P]>
+  } &
+  {
+    readonly [P in keyof Pick<
+      U,
+      KeysOfType<U, Reducer<any, any>>
+    >]: UnsafeReturnType<U[P]>
   }
 
 type UseStore<TState = any, TReturn = any> = (state: TState) => TReturn
@@ -86,9 +93,8 @@ type EffectMeta = {
   parent: string[]
 }
 
-
 /**
- * Configuration for the createStore 
+ * Configuration for the createStore
  */
 export interface EasyPeasyConfig<
   TInitialState extends Object = {},
@@ -107,7 +113,10 @@ export type Reducer<
   TAction extends ReduxAction = AnyAction
 > = ReduxReducer<TState>
 
-export type Dispatch<TModel, A extends ReduxAction = ReduxAction<any>> = Actions<TModel> & ReduxDispatch<A>;
+export type Dispatch<
+  TModel,
+  A extends ReduxAction = ReduxAction<any>
+> = Actions<TModel> & ReduxDispatch<A>
 
 export type Store<TModel> = Overwrite<
   ReduxStore<State<TModel>>,
@@ -120,7 +129,7 @@ export type Store<TModel> = Overwrite<
  * An effect action type.
  *
  * @example
- * 
+ *
  * import { Effect } from 'easy-peasy';
  *
  * interface Model {
@@ -145,7 +154,7 @@ export type Effect<
  * An action type.
  *
  * @example
- * 
+ *
  * import { Action } from 'easy-peasy';
  *
  * interface Model {
@@ -162,7 +171,7 @@ export type Action<TModel extends Object = {}, UPayload = void> = (
  * A select type.
  *
  * @example
- * 
+ *
  * import { Select } from 'easy-peasy';
  *
  * interface Model {
@@ -177,11 +186,11 @@ export type Select<TModel extends Object = {}, UResult = void> = (
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#effectaction
- * 
+ *
  * @example
- * 
+ *
  * import { effect } from 'easy-peasy';
- * 
+ *
  * const login = effect<Model, Credentials>(async (dispatch, payload) => {
  *   const user = await loginService(payload)
  *   dispatch.session.loginSucceeded(user)
@@ -200,7 +209,7 @@ export function effect<
  * https://github.com/ctrlplusb/easy-peasy#selectselector
  *
  * @example
- * 
+ *
  * import { select } from 'easy-peasy';
  *
  * const totalPrice = select<ShoppingBasketModel, number>(state =>
@@ -234,7 +243,7 @@ export function reducer<TState extends Object = {}>(
  * https://github.com/ctrlplusb/easy-peasy#createstoremodel-config
  *
  * @example
- * 
+ *
  * import { createStore } from 'easy-peasy';
  *
  * interface Model {
@@ -258,7 +267,7 @@ export function createStore<TModel extends Object = {}>(
  * https://github.com/ctrlplusb/easy-peasy#usestoremapstate-externals
  *
  * @example
- * 
+ *
  * import { useStore } from 'easy-peasy';
  *
  * const todos = useStore<Model, Array<Todo>>(state => state.todos.items);
@@ -277,7 +286,7 @@ export function useStore<TModel extends Object = {}, TReturn = any>(
  * https://github.com/ctrlplusb/easy-peasy#useactionmapaction
  *
  * @example
- * 
+ *
  * import { useAction } from 'easy-peasy';
  *
  * const addTodo = useAction<Model, Todo>(dispatch => dispatch.todos.add);
@@ -296,7 +305,7 @@ export function useAction<
  * https://github.com/ctrlplusb/easy-peasy#storeprovider
  *
  * @example
- * 
+ *
  * import { StoreProvider } from 'easy-peasy';
  *
  * ReactDOM.render(

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,7 +143,7 @@ export type Effect<
   getState: () => State<Model>,
   injections: Injections,
   meta: EffectMeta,
-) => Result
+) => Promise<Result>
 
 /**
  * An action type.
@@ -288,10 +288,9 @@ export function useStore<Model extends Object = {}, Result = any>(
  *
  * addTodo({ id: 1, text: 'foo' });
  */
-export function useAction<
-  Model extends Object = {},
-  Result = any
->(mapAction: (actions: Dispatch<Model>) => Result): Result
+export function useAction<Model extends Object = {}, Result = any>(
+  mapAction: (actions: Dispatch<Model>) => Result,
+): Result
 
 /**
  * https://github.com/ctrlplusb/easy-peasy#storeprovider

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "memoize-one": "^5.0.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "shallowequal": "^1.1.0"
+    "shallowequal": "^1.1.0",
+    "type-zoo": "^3.3.0",
+    "typelevel-ts": "^0.3.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.6",
+  "version": "1.8.0-alpha.7",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",
   "module": "dist/easy-peasy.esm.js",
+  "typings": "./index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",
@@ -53,6 +54,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@types/react": "^16.7.20",
     "app-root-dir": "^1.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
@@ -83,7 +85,11 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-uglify": "^6.0.2"
+    "rollup-plugin-uglify": "^6.0.2",
+    "type-zoo": "^3.3.0",
+    "typelevel-ts": "^0.3.5",
+    "typescript": "^3.2.4",
+    "typings-tester": "^0.3.2"
   },
   "jest": {
     "collectCoverageFrom": [
@@ -132,7 +138,7 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "all",
-    "parser": "flow"
+    "parser": "typescript"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "@types/react": "^16.7.20",
+    "@types/react-dom": "^16.0.11",
     "app-root-dir": "^1.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.8",
+  "version": "1.8.0-alpha.9",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.4",
+  "version": "1.8.0-alpha.5",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.7.1",
+  "version": "1.8.0-alpha.0",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.0",
+  "version": "1.8.0-alpha.1",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",
@@ -9,7 +9,8 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/register": "^7.0.0",
     "@types/react": "^16.7.20",
     "@types/react-dom": "^16.0.11",
+    "@types/react-redux": "^7.0.1",
     "app-root-dir": "^1.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",
     "@types/react": "^16.7.20",
     "@types/react-dom": "^16.0.11",
@@ -82,6 +83,7 @@
     "prop-types": "^15.6.2",
     "react": "16.8.0-alpha.1",
     "react-dom": "16.8.0-alpha.1",
+    "react-redux": "^6.0.0",
     "react-testing-library": "^5.2.3",
     "rimraf": "^2.6.2",
     "rollup": "^1.1.2",
@@ -91,8 +93,6 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-uglify": "^6.0.2",
-    "type-zoo": "^3.3.0",
-    "typelevel-ts": "^0.3.5",
     "typescript": "^3.2.4",
     "typings-tester": "^0.3.2"
   },
@@ -100,11 +100,12 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"
     ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/(coverage|dist|node_modules|tools)/"
-    ],
     "setupFiles": [
       "<rootDir>/node_modules/regenerator-runtime/runtime"
+    ],
+    "testMatch": [ "**/?(*.)+(spec|test).[jt]s?(x)" ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/(coverage|dist|node_modules|tools)/"
     ]
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.5",
+  "version": "1.8.0-alpha.6",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.7",
+  "version": "1.8.0-alpha.8",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "1.8.0-alpha.1",
+  "version": "1.8.0-alpha.4",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -1,0 +1,7 @@
+import { checkDirectory } from 'typings-tester'
+
+describe('TypeScript definitions', () => {
+  it('should compile against index.d.ts', () => {
+    checkDirectory(`${__dirname}/typescript`)
+  })
+})

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -12,7 +12,9 @@ import {
   Effect,
   Reducer,
   Select,
+  State,
 } from 'easy-peasy'
+import { connect } from 'react-redux'
 
 /**
  * Firstly you define your Model
@@ -125,3 +127,15 @@ ReactDOM.render(
   </StoreProvider>,
   document.getElementById('root'),
 )
+
+/**
+ * We also support typing react-redux
+ */
+
+const Counter: React.SFC<{ counter: number }> = ({ counter }) => (
+  <div>{counter}</div>
+)
+
+connect((state: State<Model>) => ({
+  counter: state.counter,
+}))(Counter)

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -20,6 +20,10 @@ import { connect } from 'react-redux'
  * Firstly you define your Model
  */
 
+interface Injections {
+  appId: string
+}
+
 interface TodosModel {
   items: Array<string>
   firstItem: Select<TodosModel, string | void>
@@ -36,6 +40,7 @@ interface Model {
   todos: TodosModel
   user: UserModel
   counter: Reducer<number>
+  printDebugInfo: Effect<Model, void, void, Injections>
 }
 
 /**
@@ -79,6 +84,9 @@ const store = createStore<Model>({
         return state
     }
   }),
+  printDebugInfo: effect((state, payload, getState, injections) => {
+    console.log(`App id: ${injections.appId}`)
+  }),
 })
 
 /**
@@ -98,8 +106,8 @@ function MyComponent() {
   //  As you can return "anything" from your mapState you need to provide the
   //  expected type of the mapped state. The state itself will be typed and
   //  then validated against the expected result type.
-  //                                  👇
-  const token = useStore<Model>(state => state.user.token)
+  //                               👇
+  const token = useStore<Model, string | void>(state => state.user.token)
 
   //  Similar to the mapState, the mapAction can return an action that accepts
   //  any "payload" type. Therefore we explicity state the payload type of the

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -42,7 +42,7 @@ interface Model {
   todos: TodosModel
   user: UserModel
   counter: Reducer<number>
-  printDebugInfo: Effect<Model, void, void, Injections>
+  printDebugInfo: Effect<Model, void, string, Injections>
 }
 
 /**
@@ -87,7 +87,9 @@ const store = createStore<Model>({
     }
   }),
   printDebugInfo: effect((state, payload, getState, injections) => {
-    console.log(`App id: ${injections.appId}`)
+    const msg = `App id: ${injections.appId}`
+    console.log(msg)
+    return msg
   }),
 })
 
@@ -111,7 +113,8 @@ function MyComponent() {
     login: dispatch.user.login,
     printDebugInfo: dispatch.printDebugInfo,
   }))
-  printDebugInfo()
+  const msg = printDebugInfo()
+  const poop = msg + 'should_be_string'
   return (
     <button onClick={() => login({ username: 'foo', password: 'bar' })}>
       {token || 'Log in'}

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -9,7 +9,6 @@ import {
   useAction,
   useStore,
   Action,
-  Actions,
   Dispatch,
   Effect,
   Reducer,
@@ -86,7 +85,7 @@ const store = createStore<Model>({
         return state
     }
   }),
-  printDebugInfo: effect((state, payload, getState, injections) => {
+  printDebugInfo: effect(async (state, payload, getState, injections) => {
     const msg = `App id: ${injections.appId}`
     console.log(msg)
     return msg

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -112,8 +112,9 @@ function MyComponent() {
     login: dispatch.user.login,
     printDebugInfo: dispatch.printDebugInfo,
   }))
-  const msg = printDebugInfo()
-  const poop = msg + 'should_be_string'
+  printDebugInfo().then(result => {
+    console.log(result + 'should_be_string')
+  })
   return (
     <button onClick={() => login({ username: 'foo', password: 'bar' })}>
       {token || 'Log in'}

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -41,7 +41,8 @@ interface Model {
   todos: TodosModel
   user: UserModel
   counter: Reducer<number>
-  printDebugInfo: Effect<Model, void, string, Injections>
+  printDebugInfo: Effect<Model, void, Injections, Promise<string>>
+  sayHello: Effect<Model, void, Injections>
 }
 
 /**
@@ -90,6 +91,9 @@ const store = createStore<Model>({
     console.log(msg)
     return msg
   }),
+  sayHello: effect(() => {
+    console.log('Hello world')
+  }),
 })
 
 /**
@@ -108,12 +112,18 @@ store.dispatch.printDebugInfo()
  */
 function MyComponent() {
   const token = useStore((state: State<Model>) => state.user.token)
-  const { login, printDebugInfo } = useAction((dispatch: Dispatch<Model>) => ({
-    login: dispatch.user.login,
-    printDebugInfo: dispatch.printDebugInfo,
-  }))
+  const { login, printDebugInfo, sayHello } = useAction(
+    (dispatch: Dispatch<Model>) => ({
+      login: dispatch.user.login,
+      printDebugInfo: dispatch.printDebugInfo,
+      sayHello: dispatch.sayHello,
+    }),
+  )
   printDebugInfo().then(result => {
     console.log(result + 'should_be_string')
+  })
+  sayHello().then(() => {
+    console.log('Goodbye')
   })
   return (
     <button onClick={() => login({ username: 'foo', password: 'bar' })}>

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -9,6 +9,7 @@ import {
   useAction,
   useStore,
   Action,
+  Actions,
   Dispatch,
   Effect,
   Reducer,
@@ -98,14 +99,19 @@ console.log(store.getState().todos.firstItem)
 
 store.dispatch({ type: 'COUNTER_INCREMENT' })
 
-store.dispatch.todos.addTodo('Install typescript')
+store.dispatch.todos.addTodo('jello')
+store.dispatch.printDebugInfo()
 
 /**
  * You can access state via hooks
  */
 function MyComponent() {
   const token = useStore((state: State<Model>) => state.user.token)
-  const login = useAction((dispatch: Dispatch<Model>) => dispatch.user.login)
+  const { login, printDebugInfo } = useAction((dispatch: Dispatch<Model>) => ({
+    login: dispatch.user.login,
+    printDebugInfo: dispatch.printDebugInfo,
+  }))
+  printDebugInfo()
   return (
     <button onClick={() => login({ username: 'foo', password: 'bar' })}>
       {token || 'Log in'}

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react'
+import {
+  createStore,
+  effect,
+  reducer,
+  select,
+  useAction,
+  useStore,
+  Action,
+  Effect,
+  Select,
+  Reducer,
+  StoreProvider,
+} from 'easy-peasy'
+
+enum Color {
+  Red = 1,
+  Green = 2,
+  Blue = 3,
+}
+
+interface Injections {
+  axios: { get: (url: string) => Promise<any> }
+}
+
+interface Todo {
+  id: number
+  text: string
+}
+
+interface TodosModel {
+  items: Array<Todo>
+  firstItem: Select<TodosModel, Todo | void>
+  addItem: Action<TodosModel, Todo>
+}
+
+interface RouterState {
+  history: {}
+  push: () => undefined
+}
+
+interface NestedStuffModel {
+  counter: number
+  increment: Action<NestedStuffModel>
+}
+
+interface Model {
+  name: string
+  age: 35
+  coords: [number, number]
+  favouriteColor: Color
+  todos: TodosModel
+  foo: Effect<Model, Todo, void, Injections>
+  bar: Action<Model>
+  router: Reducer<RouterState>
+  really: {
+    ridiculously: {
+      deeply: {
+        nested: {
+          stuff: NestedStuffModel
+        }
+      }
+    }
+  }
+}
+
+const todos: TodosModel = {
+  items: [],
+  firstItem: select(state => {
+    return state.items.length > 0 ? state.items[0] : undefined
+  }),
+  addItem: (state, payload) => {
+    state.firstItem
+    state.items.push(payload)
+  },
+}
+
+const model: Model = {
+  name: 'Bob',
+  age: 35,
+  coords: [123, 456],
+  favouriteColor: Color.Red,
+  todos,
+  foo: effect(async (dispatch, payload, getState, injections, meta) => {
+    await injections.axios.get('http:/foo')
+    dispatch.todos.addItem({ id: 1, text: 'foo' })
+    const state = getState()
+    state.todos
+  }),
+  bar: state => {
+    state.age += 1
+    state.todos.items
+  },
+  router: reducer((state = { history: [], push: () => undefined }, action) => {
+    state.history
+    return state
+  }),
+  really: {
+    ridiculously: {
+      deeply: {
+        nested: {
+          stuff: {
+            counter: 1,
+            increment: state => {},
+          },
+        },
+      },
+    },
+  },
+}
+
+const store = createStore(model)
+
+store.dispatch({
+  type: 'MY_BESPOKE_ACTION',
+  payload: 'I love redux'
+})
+store.getState().coords
+store.getState().todos.firstItem
+store.dispatch.todos.addItem({
+  id: 1,
+  text: 'Foo',
+})
+store.dispatch.really.ridiculously.deeply.nested.stuff.increment()
+
+const counter = useStore<Model, number>(state => {
+  return state.really.ridiculously.deeply.nested.stuff.counter
+})
+
+const addTodo = useAction<Model, Todo>(actions => {
+  return actions.todos.addItem
+})
+
+addTodo({
+  id: 1,
+  text: 'foo',
+})
+
+const app = <StoreProvider store={store}>Woot!</StoreProvider>

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -140,7 +140,7 @@ ReactDOM.render(
   <StoreProvider store={store}>
     <MyComponent />
   </StoreProvider>,
-  document.getElementById('root'),
+  document.createElement('div'),
 )
 
 /**

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -107,7 +107,7 @@ function MyComponent() {
   //  expected type of the mapped state. The state itself will be typed and
   //  then validated against the expected result type.
   //                               👇
-  const token = useStore<Model, string | void>(state => state.user.token)
+  const token = useStore<Model, string | undefined>(state => state.user.token)
 
   //  Similar to the mapState, the mapAction can return an action that accepts
   //  any "payload" type. Therefore we explicity state the payload type of the

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -9,6 +9,7 @@ import {
   useAction,
   useStore,
   Action,
+  Dispatch,
   Effect,
   Reducer,
   Select,
@@ -103,21 +104,8 @@ store.dispatch.todos.addTodo('Install typescript')
  * You can access state via hooks
  */
 function MyComponent() {
-  //  As you can return "anything" from your mapState you need to provide the
-  //  expected type of the mapped state. The state itself will be typed and
-  //  then validated against the expected result type.
-  //                               👇
-  const token = useStore<Model, string | undefined>(state => state.user.token)
-
-  //  Similar to the mapState, the mapAction can return an action that accepts
-  //  any "payload" type. Therefore we explicity state the payload type of the
-  //  action we expect to be mapping out. This will be validated against the
-  //  typed dispatch mounted actions.
-  //                                  👇
-  const login = useAction<Model, { username: string; password: string }>(
-    dispatch => dispatch.user.login,
-  )
-
+  const token = useStore((state: State<Model>) => state.user.token)
+  const login = useAction((dispatch: Dispatch<Model>) => dispatch.user.login)
   return (
     <button onClick={() => login({ username: 'foo', password: 'bar' })}>
       {token || 'Log in'}

--- a/src/__tests__/typescript/implementation.tsx
+++ b/src/__tests__/typescript/implementation.tsx
@@ -28,20 +28,20 @@ interface Todo {
   text: string
 }
 
+interface RouterState {
+  history: {}
+  push: () => undefined
+}
+
 interface TodosModel {
   items: Array<Todo>
   firstItem: Select<TodosModel, Todo | void>
   addItem: Action<TodosModel, Todo>
 }
 
-interface RouterState {
-  history: {}
-  push: () => undefined
-}
-
-interface NestedStuffModel {
+interface DeeplyNestedModel {
   counter: number
-  increment: Action<NestedStuffModel>
+  increment: Action<DeeplyNestedModel>
 }
 
 interface Model {
@@ -57,7 +57,7 @@ interface Model {
     ridiculously: {
       deeply: {
         nested: {
-          stuff: NestedStuffModel
+          stuff: DeeplyNestedModel
         }
       }
     }
@@ -72,6 +72,8 @@ const todos: TodosModel = {
   addItem: (state, payload) => {
     state.firstItem
     state.items.push(payload)
+    // typings:expect-error
+    state.firstItem = undefined // CANNOT ASSIGN TO SELECT RESULTS!
   },
 }
 
@@ -86,6 +88,9 @@ const model: Model = {
     dispatch.todos.addItem({ id: 1, text: 'foo' })
     const state = getState()
     state.todos
+    state.router.history
+    // typings:expect-error
+    state.router = { history: [], push: () => undefined } // CANNOT ASSIGN TO ROUTER RESULT
   }),
   bar: state => {
     state.age += 1
@@ -113,7 +118,7 @@ const store = createStore(model)
 
 store.dispatch({
   type: 'MY_BESPOKE_ACTION',
-  payload: 'I love redux'
+  payload: 'I love redux',
 })
 store.getState().coords
 store.getState().todos.firstItem
@@ -126,6 +131,8 @@ store.dispatch.really.ridiculously.deeply.nested.stuff.increment()
 const counter = useStore<Model, number>(state => {
   return state.really.ridiculously.deeply.nested.stuff.counter
 })
+
+const added = counter + 1
 
 const addTodo = useAction<Model, Todo>(actions => {
   return actions.todos.addItem

--- a/src/__tests__/typescript/tsconfig.json
+++ b/src/__tests__/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015", "dom"],
+    "jsx": "react",
+    "strict": true,
+    "baseUrl": "../../..",
+    "paths": {
+      "easy-peasy": ["index.d.ts"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
+"@types/prop-types@*":
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
+
+"@types/react@^16.7.20":
+  version "16.7.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
+  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1673,7 +1686,7 @@ commander@^2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
   integrity sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==
 
-commander@^2.14.1, commander@^2.8.1, commander@^2.9.0:
+commander@^2.12.2, commander@^2.14.1, commander@^2.8.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -1820,6 +1833,11 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   integrity sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.1.tgz#4cfbf637a577497036ebcd7e32647ef19a0b8076"
+  integrity sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.4"
@@ -6624,10 +6642,20 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-zoo@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/type-zoo/-/type-zoo-3.3.0.tgz#d5b59393b09a48ac30380c50e2369e828817e9b3"
+  integrity sha512-ID2kIg4QMbujPOpphFvSl7yyk0JaN2+5m2cprhxpzJqYWHhozLbYOHCAZqq7j1PPfzLe8XrYeZfPb99v96WVRw==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typelevel-ts@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/typelevel-ts/-/typelevel-ts-0.3.5.tgz#9f242c193fa6c5489d2342c642ab8912a065af9d"
+  integrity sha512-VZKF0ak5RNgrPkpI2uJJL0WBqNcj67+hzYzD6SwoxzrgvgjP24gskqniXd62UY5rrJCxd3q/iChtxKcHC6fRvA==
 
 typescript-eslint-parser@^16.0.0:
   version "16.0.1"
@@ -6642,7 +6670,29 @@ typescript@^2.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
   integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
 
-uglify-js@^3.1.4, uglify-js@^3.4.9:
+typescript@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+
+typings-tester@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/typings-tester/-/typings-tester-0.3.2.tgz#04cc499d15ab1d8b2d14dd48415a13d01333bc5b"
+  integrity sha512-HjGoAM2UoGhmSKKy23TYEKkxlphdJFdix5VvqWFLzH1BJVnnwG38tpC6SXPgqhfFGfHY77RlN1K8ts0dbWBQ7A==
+  dependencies:
+    commander "^2.12.2"
+
+uglify-js@^2.6:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.4.9:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
   integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,6 +385,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz#55d240536bd314dcbbec70fd949c5cabaed1de29"
+  integrity sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-arrow-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
@@ -630,6 +637,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-typescript@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz#bce7c06300434de6a860ae8acf6a442ef74a99d1"
+  integrity sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 "@babel/plugin-transform-unicode-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b"
@@ -707,6 +722,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/preset-typescript@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz#49ad6e2084ff0bfb5f1f7fb3b5e76c434d442c7f"
+  integrity sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.1.0"
+
 "@babel/register@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
@@ -731,6 +754,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.2.0":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -3052,6 +3082,13 @@ header-case@^1.0.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.3"
+
+hoist-non-react-statics@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^3.0.0:
   version "3.0.0"
@@ -5457,6 +5494,23 @@ react-dom@16.8.0-alpha.1:
     prop-types "^15.6.2"
     scheduler "^0.13.0-alpha.1"
 
+react-is@^16.6.3, react-is@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+  integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-redux@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.0.tgz#09e86eeed5febb98e9442458ad2970c8f1a173ef"
+  integrity sha512-EmbC3uLl60pw2VqSSkj6HpZ6jTk12RMrwXMBdYtM6niq0MdEaRq9KYCwpJflkOZj349BLGQm1MI/JO1W96kLWQ==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    hoist-non-react-statics "^3.2.1"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.3"
+
 react-testing-library@^5.2.3:
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.4.4.tgz#3fa787999492be94b228e4540a7211556bf4fd94"
@@ -6697,17 +6751,7 @@ typings-tester@^0.3.2:
   dependencies:
     commander "^2.12.2"
 
-uglify-js@^2.6:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-js@^3.4.9:
+uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
   integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,7 +841,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react@^16.7.20":
+"@types/react-dom@^16.0.11":
+  version "16.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.11.tgz#bd10ccb0d9260343f4b9a49d4f7a8330a5c1f081"
+  integrity sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.7.20":
   version "16.7.20"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
   integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-redux@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.1.tgz#9dd2503be7a9861c5a092bf1c5050b7ade4dc62e"
+  integrity sha512-+DIH7TI2MT4Ke4lOrRMgNy//DzTDIzv5QwkJSD6AVrlsIgzf7yMM0JoWL5wJUXYwKQ2f1FgvwlvIVGD2QWQnew==
+  dependencies:
+    "@types/react" "*"
+    redux "^4.0.0"
+
 "@types/react@*", "@types/react@^16.7.20":
   version "16.7.20"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
@@ -5571,7 +5579,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.1:
+redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
   integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==


### PR DESCRIPTION
__NOTE__: We have been iterating on the types for the lifetime of this PR. Changes are being made, but I am updating this comment to reflect the latest version of the definitions. 

Your help in testing them would be greatly valued! 👍

---

Firstly, I must absolutely stress that none of this work would have been achieved without the monumental effort of @christianchown on his typings work via #33! To be honest given the API of `easy-peasy` I never considered that reasonably sound typings would be at all possible. @christianchown proved me wrong with his work. 

Originally I tried to see if I could solve the issue that was being faced in #33 regarding being bound to a maximum of 4 levels deep of typed state. In doing so however I began to spin out a solution which had a significantly different type definition implementation to that of #33. Eventually it diverged so much that I eventually settled on the idea of spinning out a completely alternative approach rather than trying to change #33 too much.

So I have created this PR instead of trying to comment over #33. I hope that we can take the best of the two to come up with a final solution we are all happy with.

The core approach used in these typing is the use of generic recursive type aliases. I discovered the concept by chance after many hours of googling. The approach appears to work very well for our case, however, I am not sure on how it will perform against large model definitions.

This PR also differs in the manner by which you define your model. Given that I was able to leverage generic recursive type aliases I was able to allow state, actions, selectors, and reducers to be collocated.

Below is a pretty comprehensive example.

```typescript
import * as React from 'react'
import * as ReactDOM from 'react-dom'
import {
  createStore,
  effect,
  reducer,
  select,
  StoreProvider,
  useAction,
  useStore,
  Action,
  Dispatch,
  Effect,
  Reducer,
  Select,
  State,
} from 'easy-peasy'
import { connect } from 'react-redux'

/**
 * Firstly you define your Model
 */

interface TodosModel {
  items: Array<string>
  firstItem: Select<TodosModel, string | void>
  addTodo: Action<TodosModel, string>
}

interface UserModel {
  token?: string
  loggedIn: Action<UserModel, string>
  login: Effect<Model, { username: string; password: string }>
}

interface Model {
  todos: TodosModel
  user: UserModel
  counter: Reducer<number>
}

/**
 * Then you create your store.
 * Note that as we pass the Model into the `createStore` function, so all of our
 * model definition is typed correctly, including inside the actions/helpers etc.
 */

const store = createStore<Model>({
  todos: {
    items: [],
    firstItem: select(state =>
      state.items.length > 0 ? state.items[0] : undefined,
    ),
    addTodo: (state, payload) => {
      state.items.push(payload)
    },
  },
  user: {
    token: undefined,
    loggedIn: (state, payload) => {
      state.token = payload
    },
    login: effect(async (dispatch, payload) => {
      const response = await fetch('/login', {
        method: 'POST',
        body: JSON.stringify(payload),
        headers: {
          'Content-Type': 'application/json',
        },
      })
      const { token } = await response.json()
      dispatch.user.loggedIn(token)
    }),
  },
  counter: reducer((state = 0, action) => {
    switch (action.type) {
      case 'COUNTER_INCREMENT':
        return state + 1
      default:
        return state
    }
  }),
})

/**
 * You can use the "standard" store APIs
 */

console.log(store.getState().todos.firstItem)

store.dispatch({ type: 'COUNTER_INCREMENT' })

store.dispatch.todos.addTodo('Install typescript')

/**
 * You can access state via hooks
 *
 * FYI - see @formula349's tip so that you don't have to constantly provide
 *       types on your useStore and useAction hooks:
 *       https://github.com/ctrlplusb/easy-peasy/issues/21#issuecomment-457644655
 */
function MyComponent() {
  const token = useStore((state: State<Model>) => 
    state.user.token
  )

  const login = useAction((dispatch: Dispatch<Model>) => 
	dispatch.user.login,
  )

  return (
    <button onClick={() => login({ username: 'foo', password: 'bar' })}>
      {token || 'Log in'}
    </button>
  )
}

/**
 * Expose the store to your app as normal
 */

ReactDOM.render(
  <StoreProvider store={store}>
    <MyComponent />
  </StoreProvider>,
  document.getElementById('root'),
)

/**
 * We also support typing react-redux
 */

const Counter: React.SFC<{ counter: number }> = ({ counter }) => (
  <div>{counter}</div>
)

connect((state: State<Model>) => ({
  counter: state.counter,
}))(Counter)
```

For anyone interested in testing these you can install:

```
npm install easy-peasy@typescript
```

Things I dislike or need to be considered about these typings:

 - [ ] Having to explicitly add the typing for any injections to any Effect (`Effect<Model, void, Injections>`). It would be great to have an intermediary type that allows us to bake in the value for all effects (`type EffectWithInjections = Effect<*, *, Injections>`) and then be able to declare effects with the new type. 
 - [ ] Unknown performance properties. The recursive type resolution may bite us. We should try testing against a significantly large definition to ensure this isn't a blocker. 

@christianchown - please feel free to merge any bits of this into your PR. I am not preferring one over the other for now, but it may be useful to evolve two forms until we can eventually merge into a single solution that is effective.

Like I said above I still have concerns about the perf implications of the design of these types.