### PR TITLE
Adds support for actions listeners via the `when` helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { createStore, effect, reducer, select } from './easy-peasy'
+import { createStore, effect, reducer, select, when } from './easy-peasy'
 import { useStore, useAction } from './hooks'
 import StoreProvider from './provider'
 
@@ -10,4 +10,5 @@ export {
   StoreProvider,
   useAction,
   useStore,
+  when,
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -12,7 +12,7 @@ module.exports = wallaby => ({
   testFramework: 'jest',
   env: {
     type: 'node',
-    runner: '/Users/seanmatheson/.nvm/versions/node/v10.8.0/bin/node',
+    runner: 'node',
   },
   compilers: {
     'src/**/*.js': wallaby.compilers.babel(babelConfig),


### PR DESCRIPTION
Closes #58 

```javascript
import { when } from 'easy-peasy'; // 👈 import the helper

const store = createStore({
  user: {
    token: '',
    loggedIn: (state, payload) => {
      state.token = payload;
    },
    logIn: effect(async (dispatch, payload) => {
      const token = await loginService(payload);
      dispatch.user.loggedIn(token);
    },
    logOut: (state) => {
      state.token = '';
    },
  },
  audit: {
    logs: [],
    add: (state, payload) => {
      state.logs.push(payload)
    },
    //  👇 name your listeners
    userListeners: when(actions => ({
      // 👇 we attach a listener to the "logIn" effect
      [actions.user.logIn]: dispatch => {
        dispatch.audit.add('User logged in')
      },
      // 👇 we attach a listener to the "logOut" action
      [actions.user.logOut]: dispatch => {
        dispatch.audit.add('User logged out')
      },
    })),
  },
});

// 👇 the login effect will fire, and then any listeners will execute after complete
store.dispatch.user.login({ username: 'mary', password: 'foo123' });
```