### PR TITLE
Reworks listener API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
-import { createStore, effect, reducer, select, when } from './easy-peasy'
+import { createStore, effect, listeners, reducer, select } from './easy-peasy'
 import { useStore, useAction } from './hooks'
 import StoreProvider from './provider'
 
 export {
   createStore,
   effect,
+  listeners,
   reducer,
   select,
   StoreProvider,
   useAction,
   useStore,
-  when,
 }


### PR DESCRIPTION
I let this one sit for a while and in the end I didn't like the `when` implementation that we had. The biggest reason was that only strings/numbers are technically allowed as a key to an object map. Therefore I was doing a hack involving `toString` on actions.  

I feel like this rework is more explicit and plays nicer with types.


### listeners(attach)

Allows you to attach listeners to any action from your model, which will then be fired after the targetted action is exectuted.

This enables parts of your model to respond to actions being fired in other parts of your model. For example you could have a "notifications" model that populates based on certain actions being fired (logged in, product added to basket, etc).

Note: If any action being listened to does not complete successfully (i.e. throws an exception), then no listeners will be fired.

```javascript
const model = {
  ...,
  notificationlisteners: listeners((actions, on) => {
    on(actions.user.loggedIn, (dispatch) => {
      dispatch.notifications.set('User logged in');
    })
  })
};
```

**Arguments:**

  - attach (Function, required)

    The attach callback function allows you to attach the listeners to specific actions. It is provided the following arguments:

    - `actions` (Object, required)

      The actions (and effects) of the store.

    - `on` (Function, required)

      Allows you to attach a listener to an action. It expects the following arguments:

      - `action` (Function, required)

        The target action you wish to listen to - you provide the direct reference to the action.

      - `handler` (Function, required)

        The handler function to be executed after the target action is fired successfully. It will receive the following arguments:

        - `dispatch` (required)

          The Redux store `dispatch` instance. This will have all the Easy Peasy actions bound to it allowing you to dispatch additional actions.

        - `payload` (Any, not required)

          The original payload that the targetted action received.

        - `getState` (Function, required)

          When executed it will provide the root state of your model.

        - `injections` (Any, not required, default=undefined)

          Any dependencies that were provided to the `createStore` configuration will be exposed as this argument. See the [`createStore`](#createstoremodel-config) docs on how to specify them.

**Example**

```javascript
import { listeners } from 'easy-peasy'; // 👈 import the helper

const store = createStore({
  user: {
    token: '',
    loggedIn: (state, payload) => {
      state.token = payload;
    },
    logIn: effect(async (dispatch, payload) => {
      const token = await loginService(payload);
      dispatch.user.loggedIn(token);
    },
    logOut: (state) => {
      state.token = '';
    }
  },
  audit: {
    logs: [],
    add: (state, payload) => {
      state.logs.push(payload)
    },
    //  👇 name your listeners
    userListeners: listeners((actions, on) => {
      // 👇 we attach a listener to the "logIn" effect
      on(actions.user.logIn, (dispatch, payload) => {
        dispatch.audit.add(`${payload.username} logged in`);
      });
      // 👇 we attach a listener to the "logOut" action
      on(actions.user.logOut, dispatch => {
        dispatch.audit.add('User logged out');
      });
    }))
  }
});

// 👇 the login effect will fire, and then any listeners will execute after complete
store.dispatch.user.login({ username: 'mary', password: 'foo123' });
```

Closes #58 