### PR TITLE
Adds string action listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,8 @@ Allows you to attach listeners to any normal or thunk action. Listeners are them
 
 This enables parts of your model to respond to actions being fired in other parts of your model. For example you could have a "notifications" model that populates based on certain actions being fired (logged in, product added to basket, etc).
 
+It also supports attach listeners to a "string" named action. This allows with interop with 3rd party libraries, or aids in migration.
+
 Note: If any action being listened to does not complete successfully (i.e. throws an exception), then no listeners will be fired.
 
 <details>
@@ -1183,9 +1185,9 @@ Note: If any action being listened to does not complete successfully (i.e. throw
 
     Allows you to attach a listener to an action. It expects the following arguments:
 
-    - `action` (Function, required)
+    - `action` (Function | string, required)
 
-      The target action you wish to listen to - you provide the direct reference to the action.
+      The target action you wish to listen to - you provide the direct reference to the action, or the string name of it.
 
     - `thunk` (Function, required)
 
@@ -1234,6 +1236,32 @@ const notificationModel = {
 const model = {
   user: userModel,
   notification: notificationModel
+};
+```
+</p>
+</details>
+
+<details>
+<summary>Example listening to string named action</summary>
+<p>
+
+```javascript
+import { listen } from 'easy-peasy';
+
+const model = {
+  msg: '',
+  set: (state, payload) => { state.msg = payload; },
+
+  listeners: listen((on) => {
+    //      👇 passing in action name
+    on('ROUTE_CHANGED', (actions, payload) => {
+      //                            👆
+      // We won't know the type of payload, so it will be "any".
+      // You will have to annotate it manually if you are using
+      // Typescript and care about the payload type.
+      actions.set(`Route was changed`);
+    });
+  })
 };
 ```
 </p>

--- a/index.d.ts
+++ b/index.d.ts
@@ -293,11 +293,13 @@ export type Listen<
   StoreModel extends Object = {}
 > = {
   (
-    on: <ListenAction extends Action<any, any>>(
+    on: <ListenAction extends ActionTypes | string>(
       action: ListenAction,
       handler: (
         actions: Actions<Model>,
-        payload: ListenAction extends AsyncActionTypes
+        payload: ListenAction extends string
+          ? any
+          : ListenAction extends AsyncActionTypes
           ? ListenAction['payload']
           : Param1<ListenAction>,
         helpers: {
@@ -342,11 +344,13 @@ export function listen<
   StoreModel extends Object = {}
 >(
   attach: (
-    on: <ListenAction extends ActionTypes>(
+    on: <ListenAction extends ActionTypes | string>(
       action: ListenAction,
       handler: (
         actions: Actions<Model>,
-        payload: ListenAction extends AsyncActionTypes
+        payload: ListenAction extends string
+          ? any
+          : ListenAction extends AsyncActionTypes
           ? ListenAction['payload']
           : Param1<ListenAction>,
         helpers: {

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -1476,6 +1476,24 @@ describe('listen', () => {
     // assert
     expect(store.getState().routeChangeLogs).toEqual(['/about'])
   })
+
+  it('listening to an invalid type does nothing', () => {
+    // act
+    createStore({
+      listeners: listen(on => {
+        on(true, () => {})
+      }),
+    })
+  })
+
+  it('listening with an invalid handler does nothing', () => {
+    // act
+    createStore({
+      listeners: listen(on => {
+        on('FOO_BAR', true)
+      }),
+    })
+  })
 })
 
 describe('createTypedHooks', () => {

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -1452,6 +1452,30 @@ describe('listen', () => {
       'User logged out',
     ])
   })
+
+  it('listens to string actions', () => {
+    // arrange
+    const store = createStore({
+      routeChangeLogs: [],
+      log: (state, payload) => {
+        state.routeChangeLogs.push(payload)
+      },
+      listeners: listen(on => {
+        on('ROUTE_CHANGED', (action, payload) => {
+          action.log(payload)
+        })
+      }),
+    })
+
+    // act
+    store.dispatch({
+      type: 'ROUTE_CHANGED',
+      payload: '/about',
+    })
+
+    // assert
+    expect(store.getState().routeChangeLogs).toEqual(['/about'])
+  })
 })
 
 describe('createTypedHooks', () => {

--- a/src/__tests__/typescript/listen.ts
+++ b/src/__tests__/typescript/listen.ts
@@ -47,6 +47,9 @@ createStore<StoreModel>({
         injections.id + 7331
         meta.parent.concat(meta.path)
       })
+      on('ROUTE_CHANGED', (actions, payload) => {
+        actions.log('Route changed')
+      })
     }),
   },
 })


### PR DESCRIPTION
This expands the `listen` helper to support listening to "string" action names. This allows for interop with 3rd party libraries, whilst also helping with migration paths.

```typescript
import { listen } from 'easy-peasy';

const model = {
  msg: '',
  set: (state, payload) => { state.msg = payload; },

  listeners: listen((on) => {
    //      👇 passing in action name
    on('ROUTE_CHANGED', (actions, payload) => {
      //                            👆
      // We won't know the type of payload, so it will be "any".
      // You will have to annotate it manually if you are using 
      // Typescript and care about the payload type.
      actions.set(`Route was changed`);
    });
  })
};
```