### PR TITLE
Remove setTimeout and fixup tests

### DIFF
--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -94,16 +94,14 @@ describe('react', () => {
     expect(value.firstChild.textContent).toBe('foo')
 
     // act
-    const app2 = (
-      <StoreProvider store={store}>
-        <Values id={2} />
-      </StoreProvider>
-    )
-
-    rerender(app2)
-
-    // assert
-    expect(value.firstChild.textContent).toBe('foo')
+    act(() => {
+      const app2 = (
+        <StoreProvider store={store}>
+          <Values id={2} />
+        </StoreProvider>
+      )
+      rerender(app2)
+    })
 
     // ensure settimeouts fire
     act(() => {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -25,16 +25,10 @@ export function useStore(mapState, dependencies = []) {
         return
       }
       stateRef.current = newState
-      // The settimeout wrap fixes a strange issue where a setState would
-      // fire but the associated hook wouldn't receive it. It's almost as
-      // if the effect was handled in a synchronous manner in some part of
-      // the React reconciliation process that ended up with it not
-      // propagating
-      setTimeout(() => {
-        if (isActive.current) {
-          setState(newState)
-        }
-      })
+
+      if (isActive.current) {
+        setState(newState)
+      }
     }
     calculateState()
     const unsubscribe = store.subscribe(calculateState)


### PR DESCRIPTION
Thanks for all your hard work on this, loving easy-peasy a lot.

In Chrome I'm seeing a bunch of setTimeout timing warnings due to setTimeout wrapping state setting. I saw your comment above it, but is there a test showing what happens when it is not wrapped? I started to make an issue about this, but thought a PR would be more helpful. 

I removed it and ran the tests and it failed on `maps state when prop dependency changes`.  To fix it I wrapped the second re-render in an `act` call to ensure that the effects are flushed before checking the DOM, and only checked it for the new value. I'm pretty sure this is the correct way to test with hooks, but I could be wrong.

## Other notes
- React is also throwing an message about the Counter components needing `act`.
- I think all of the `jest.runAllTimers()` can also be removed, but didn't want to create a large changeset without first understanding their need.

## Chrome warnings
![screen shot 2019-02-12 at 5 35 17 pm](https://user-images.githubusercontent.com/3998604/52672708-9cd6e780-2eec-11e9-8e1c-7f893a774f5b.png)

## React message during testing
```
 console.error node_modules/react-dom/cjs/react-dom.development.js:506
 Warning: An update to Counter inside a test was not wrapped in act(...).
      
When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
````