### PR TITLE
Fix issue that causes a thunk to remain uncompleted when err thrown

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",
   "module": "dist/easy-peasy.esm.js",
-  "typings": "./index.d.ts",
   "types": "./index.d.ts",
   "sideEffects": false,
   "files": [
@@ -40,7 +39,6 @@
     "react": "^16.8.0"
   },
   "dependencies": {
-    "@types/react-redux": "^7.0.1",
     "immer": "^2.0.0",
     "memoizerific": "^1.11.3",
     "redux": "^4.0.1",
@@ -63,6 +61,7 @@
     "@babel/register": "^7.0.0",
     "@types/react": "^16.8.2",
     "@types/react-dom": "^16.8.0",
+    "@types/react-redux": "^7.0.1",
     "app-root-dir": "^1.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -802,6 +802,35 @@ describe('thunks', () => {
     expect(actualResult).toBe('did something')
   })
 
+  test('completes a thunk when error is thrown', async () => {
+    // arrange
+    const model = {
+      foo: {
+        error: thunk(() => {
+          return Promise.reject()
+        }),
+        doSomething: thunk(async actions => {
+          await actions.error()
+          return 'did something'
+        }),
+      },
+    }
+    const trackActions = trackActionsMiddleware()
+    const store = createStore(model, { middleware: [trackActions] })
+    const payload = 'hello'
+    // act
+    const actualResult = await store.dispatch.foo.doSomething(payload)
+    // assert
+
+    expect(trackActions.actions).toEqual([
+      { type: '@thunk.foo.doSomething(started)', payload },
+      { type: '@thunk.foo.error(started)', payload: undefined },
+      { type: '@thunk.foo.error(completed)', payload: undefined },
+      { type: '@thunk.foo.doSomething(completed)', payload },
+    ])
+    expect(actualResult).toBe('did something')
+  })
+
   test('async', async () => {
     // arrange
     const model = {

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -779,11 +779,11 @@ describe('thunks', () => {
     const trackActions = trackActionsMiddleware()
     const store = createStore(model, { middleware: [trackActions] })
     const payload = 'hello'
-    // act
     try {
+      // act
       await store.dispatch.foo.doSomething(payload)
-      // assert
 
+      // assert
       expect(trackActions.actions).toEqual([
         { type: '@thunk.foo.doSomething(started)', payload },
         { type: '@thunk.foo.error(started)', payload: undefined },

--- a/src/__tests__/easy-peasy.test.js
+++ b/src/__tests__/easy-peasy.test.js
@@ -825,7 +825,7 @@ describe('thunks', () => {
     expect(trackActions.actions).toEqual([
       { type: '@thunk.foo.doSomething(started)', payload },
       { type: '@thunk.foo.error(started)', payload: undefined },
-      { type: '@thunk.foo.error(completed)', payload: undefined },
+      { type: '@thunk.foo.error(failed)', payload: undefined },
       { type: '@thunk.foo.doSomething(completed)', payload },
     ])
     expect(actualResult).toBe('did something')

--- a/src/easy-peasy.js
+++ b/src/easy-peasy.js
@@ -225,7 +225,7 @@ export const createStore = (model, options = {}) => {
               })
               .catch(err => {
                 references.dispatch({
-                  type: `${actionName}(completed)`,
+                  type: `${actionName}(failed)`,
                   payload: err,
                 })
               })

--- a/src/easy-peasy.js
+++ b/src/easy-peasy.js
@@ -223,6 +223,12 @@ export const createStore = (model, options = {}) => {
                 })
                 return result
               })
+              .catch(err => {
+                references.dispatch({
+                  type: `${actionName}(completed)`,
+                  payload: err,
+                })
+              })
           actionCreator[actionNameSymbol] = actionName
           actionCreatorDict[actionName] = actionCreator
           set(path, actionCreators, actionCreator)

--- a/src/easy-peasy.js
+++ b/src/easy-peasy.js
@@ -238,6 +238,7 @@ export const createStore = (model, options = {}) => {
                   type: `${name}(failed)`,
                   payload: err,
                 })
+                return Promise.reject(err)
               })
 
           actionCreator[actionNameSymbol] = name


### PR DESCRIPTION
I was making a middleware to dispatch loading states, and I found that thunks that threw an error were not marked as complete. This caused some of my state to remain unchanged when making an HTTP request that resulted in an error.