### PR TITLE
Attach mockActions middleware as the last one.

### DIFF
--- a/src/create-store.js
+++ b/src/create-store.js
@@ -35,7 +35,7 @@ export default function createStore(model, options = {}) {
 
   let mockedActions = [];
 
-  const mockActionsMiddlware = () => next => action => {
+  const mockActionsMiddleware = () => next => action => {
     if (mockActions) {
       mockedActions.push(action);
       return undefined;
@@ -106,8 +106,8 @@ export default function createStore(model, options = {}) {
       applyMiddleware(
         reduxThunk,
         dispatchActionStringListeners,
-        mockActionsMiddlware,
         ...middleware,
+        mockActionsMiddleware,
       ),
       ...enhancers,
     ),


### PR DESCRIPTION
When custom middleware fires actions, mockActions middleware is able to intercept these as well.
Provide a test case.