### PR TITLE
Adds new derived helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ type FilterActionTypes<T extends object> = Omit<
     | RegExp
     | Reducer<any, any>
     | Select<any, any>
+    | Derived<any, any, any, any, any>
     | Listen<any, any, any>
   >
 >;
@@ -59,7 +60,13 @@ type FilterStateTypes<T extends object> = Overwrite<
       Action<any, any> | Listen<any, any, any> | Thunk<any, any, any, any, any>
     >
   >,
-  Pick<T, KeysOfType<T, Select<any, any> | Reducer<any, any>>>
+  Pick<
+    T,
+    KeysOfType<
+      T,
+      Select<any, any> | Reducer<any, any> | Derived<any, any, any, any, any>
+    >
+  >
 >;
 
 /**
@@ -96,6 +103,8 @@ type RecursiveState<
     {
       [P in keyof RequiredModel]: RequiredModel[P] extends Select<any, infer R>
         ? R
+        : RequiredModel[P] extends Derived<any, any, any, any, any>
+        ? Selector<RequiredModel[P]>
         : RequiredModel[P] extends Reducer<infer R, any>
         ? R
         : RequiredModel[P] extends object
@@ -107,6 +116,8 @@ type RecursiveState<
     {
       [P in keyof OptionalModel]?: OptionalModel[P] extends Select<any, infer R>
         ? R
+        : OptionalModel[P] extends Derived<any, any, any, any, any>
+        ? Selector<OptionalModel[P]>
         : OptionalModel[P] extends Reducer<infer R, any>
         ? R
         : OptionalModel[P] extends object
@@ -394,6 +405,291 @@ export type Action<Model extends Object = {}, Payload = void> = {
 export function action<Model extends Object = {}, Payload = any>(
   action: (state: State<Model>, payload: Payload) => void | State<Model>,
 ): Action<Model, Payload>;
+
+type Arguments =
+  | [any]
+  | [any, any]
+  | [any, any, any]
+  | [any, any, any, any]
+  | [any, any, any, any, any];
+
+type OptionalArguments = void | Arguments;
+
+// Forgive me for I have sinned...
+type JoinedArgs<
+  Args extends Arguments = [any],
+  RunTimeArgs extends OptionalArguments = void
+> = RunTimeArgs extends void
+  ? Args
+  : Args extends [any]
+  ? RunTimeArgs extends [any]
+    ? [Args[0], RunTimeArgs[0]]
+    : RunTimeArgs extends [any, any]
+    ? [Args[0], RunTimeArgs[0], RunTimeArgs[1]]
+    : RunTimeArgs extends [any, any, any]
+    ? [Args[0], RunTimeArgs[0], RunTimeArgs[1], RunTimeArgs[2]]
+    : RunTimeArgs extends [any, any, any, any]
+    ? [Args[0], RunTimeArgs[0], RunTimeArgs[1], RunTimeArgs[2], RunTimeArgs[3]]
+    : RunTimeArgs extends [any, any, any, any, any]
+    ? [
+        Args[0],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3],
+        RunTimeArgs[4]
+      ]
+    : Args
+  : Args extends [any, any]
+  ? RunTimeArgs extends [any]
+    ? [Args[0], Args[1], RunTimeArgs[0]]
+    : RunTimeArgs extends [any, any]
+    ? [Args[0], Args[1], RunTimeArgs[0], RunTimeArgs[1]]
+    : RunTimeArgs extends [any, any, any]
+    ? [Args[0], Args[1], RunTimeArgs[0], RunTimeArgs[1], RunTimeArgs[2]]
+    : RunTimeArgs extends [any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3]
+      ]
+    : RunTimeArgs extends [any, any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3],
+        RunTimeArgs[4]
+      ]
+    : Args
+  : Args extends [any, any, any]
+  ? RunTimeArgs extends [any]
+    ? [Args[0], Args[1], Args[2], RunTimeArgs[0]]
+    : RunTimeArgs extends [any, any]
+    ? [Args[0], Args[1], Args[2], RunTimeArgs[0], RunTimeArgs[1]]
+    : RunTimeArgs extends [any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2]
+      ]
+    : RunTimeArgs extends [any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3]
+      ]
+    : RunTimeArgs extends [any, any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3],
+        RunTimeArgs[4]
+      ]
+    : Args
+  : Args extends [any, any, any, any]
+  ? RunTimeArgs extends [any]
+    ? [Args[0], Args[1], Args[2], Args[3], RunTimeArgs[0]]
+    : RunTimeArgs extends [any, any]
+    ? [Args[0], Args[1], Args[2], Args[3], RunTimeArgs[0], RunTimeArgs[1]]
+    : RunTimeArgs extends [any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2]
+      ]
+    : RunTimeArgs extends [any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3]
+      ]
+    : RunTimeArgs extends [any, any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3],
+        RunTimeArgs[4]
+      ]
+    : Args
+  : Args extends [any, any, any, any, any]
+  ? RunTimeArgs extends [any]
+    ? [Args[0], Args[1], Args[2], Args[3], Args[4], RunTimeArgs[0]]
+    : RunTimeArgs extends [any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        Args[4],
+        RunTimeArgs[0],
+        RunTimeArgs[1]
+      ]
+    : RunTimeArgs extends [any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        Args[4],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2]
+      ]
+    : RunTimeArgs extends [any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        Args[4],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3]
+      ]
+    : RunTimeArgs extends [any, any, any, any, any]
+    ? [
+        Args[0],
+        Args[1],
+        Args[2],
+        Args[3],
+        Args[4],
+        RunTimeArgs[0],
+        RunTimeArgs[1],
+        RunTimeArgs[2],
+        RunTimeArgs[3],
+        RunTimeArgs[4]
+      ]
+    : Args
+  : Args;
+
+/**
+ * A derived type.
+ *
+ * Useful when declaring your model.
+ *
+ * @example
+ *
+ * import { Derived } from 'easy-peasy';
+ *
+ * interface Model {
+ *   products: Array<Product>;
+ *   totalPrice: Derived<Model, number>;
+ * }
+ */
+export type Derived<
+  Model extends Object = {},
+  Result = any,
+  Args extends Arguments = [any],
+  RunTimeArgs extends OptionalArguments = void,
+  StoreModel extends Object = {}
+> = {
+  (...args: JoinedArgs<Args, RunTimeArgs>): Result;
+  type: 'derived';
+  result: Result;
+};
+
+type ArgumentSelector<
+  Model extends Object = {},
+  StoreModel extends Object = {},
+  Result = any
+> = (state: State<Model>, storeState: State<StoreModel>) => Result;
+
+export type Selector<
+  DerivedImp extends Derived<any, any, any, any, any>
+> = DerivedImp extends Derived<any, infer R, any, infer RTArgs, any>
+  ? RTArgs extends Arguments
+    ? (...args: RTArgs) => R
+    : () => R
+  : () => any;
+
+/**
+ * Allows you to declare derived state against your model.
+ *
+ * https://github.com/ctrlplusb/easy-peasy#derived
+ *
+ * @example
+ *
+ * import { derived } from 'easy-peasy';
+ *
+ * const store = createStore({
+ *   products: [],
+ *   totalPrice: derived(
+ *     [state => state.products],
+ *     products => products.reduce((acc, cur) => acc + cur.price, 0),
+ *   )
+ * });
+ */
+export function derived<
+  Model extends Object = {},
+  Result = any,
+  Args extends Arguments = [any],
+  RunTimeArgs extends OptionalArguments = void,
+  StoreModel extends Object = {}
+>(
+  argumentSelectors: Args extends [any]
+    ? [ArgumentSelector<Model, StoreModel, Args[0]>]
+    : Args extends [any, any]
+    ? [
+        ArgumentSelector<Model, StoreModel, Args[0]>,
+        ArgumentSelector<Model, StoreModel, Args[1]>
+      ]
+    : Args extends [any, any, any]
+    ? [
+        ArgumentSelector<Model, StoreModel, Args[0]>,
+        ArgumentSelector<Model, StoreModel, Args[1]>,
+        ArgumentSelector<Model, StoreModel, Args[2]>
+      ]
+    : Args extends [any, any, any, any]
+    ? [
+        ArgumentSelector<Model, StoreModel, Args[0]>,
+        ArgumentSelector<Model, StoreModel, Args[1]>,
+        ArgumentSelector<Model, StoreModel, Args[2]>,
+        ArgumentSelector<Model, StoreModel, Args[3]>
+      ]
+    : Args extends [any, any, any, any]
+    ? [
+        ArgumentSelector<Model, StoreModel, Args[0]>,
+        ArgumentSelector<Model, StoreModel, Args[1]>,
+        ArgumentSelector<Model, StoreModel, Args[2]>,
+        ArgumentSelector<Model, StoreModel, Args[3]>,
+        ArgumentSelector<Model, StoreModel, Args[4]>
+      ]
+    : any,
+  selector: (...args: JoinedArgs<Args, RunTimeArgs>) => Result,
+  memoizeLimit?: number,
+): Derived<Model, Result, Args, RunTimeArgs, StoreModel>;
 
 /**
  * A select type.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "2.2.0",
+  "version": "2.3.0-alpha.0",
   "description": "Easy peasy global state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/src/__tests__/derived.test.js
+++ b/src/__tests__/derived.test.js
@@ -1,0 +1,436 @@
+import React, { useEffect } from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, fireEvent } from 'react-testing-library';
+import {
+  action,
+  createStore,
+  derived,
+  StoreProvider,
+  useStore,
+  useActions,
+} from '../index';
+
+it('deriving against local state', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      items: ['foo'],
+      count: derived([state => state.items], items => items.length),
+    },
+  });
+
+  // assert
+  expect(store.getState().todos.count()).toBe(1);
+});
+
+it('supports multiple derived state arguments', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      countLabel: 'Count',
+      items: ['foo'],
+      count: derived(
+        [state => state.items, state => state.countLabel],
+        (items, label) => `${label}: ${items.length}`,
+      ),
+    },
+  });
+
+  // assert
+  expect(store.getState().todos.count()).toBe('Count: 1');
+});
+
+it('has a memoisation limit of 1 by default', () => {
+  // arrange
+  let runCount = 0;
+  const todoOne = { id: 1, text: 'foo' };
+  const todoTwo = { id: 2, text: 'bar' };
+  const store = createStore({
+    todos: {
+      items: [todoOne, todoTwo],
+      getById: derived([state => state.items], (items, id) => {
+        runCount += 1;
+        return items.find(x => x.id === id);
+      }),
+    },
+  });
+
+  // act
+  let todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(1);
+  expect(todo).toEqual(todoOne);
+
+  // act
+  todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(1);
+  expect(todo).toEqual(todoOne);
+
+  // act
+  todo = store.getState().todos.getById(2);
+
+  // assert
+  expect(runCount).toBe(2);
+  expect(todo).toEqual(todoTwo);
+
+  // act
+  todo = store.getState().todos.getById(2);
+
+  // assert
+  expect(runCount).toBe(2);
+  expect(todo).toEqual(todoTwo);
+
+  // act
+  todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(3);
+  expect(todo).toEqual(todoOne);
+});
+
+it('supports customisation on the memoisation limit', () => {
+  // arrange
+  let runCount = 0;
+  const todoOne = { id: 1, text: 'foo' };
+  const todoTwo = { id: 2, text: 'bar' };
+  const store = createStore({
+    todos: {
+      items: [todoOne, todoTwo],
+      getById: derived(
+        [state => state.items],
+        (items, id) => {
+          runCount += 1;
+          return items.find(x => x.id === id);
+        },
+        { limit: 2 },
+      ),
+    },
+  });
+
+  // act
+  let todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(1);
+  expect(todo).toEqual(todoOne);
+
+  // act
+  todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(1);
+  expect(todo).toEqual(todoOne);
+
+  // act
+  todo = store.getState().todos.getById(2);
+
+  // assert
+  expect(runCount).toBe(2);
+  expect(todo).toEqual(todoTwo);
+
+  // act
+  todo = store.getState().todos.getById(2);
+
+  // assert
+  expect(runCount).toBe(2);
+  expect(todo).toEqual(todoTwo);
+
+  // act
+  todo = store.getState().todos.getById(1);
+
+  // assert
+  expect(runCount).toBe(2);
+  expect(todo).toEqual(todoOne);
+});
+
+it('supports execution time arguments', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      items: [{ id: 1, text: 'foo' }],
+      getById: derived([state => state.items], (items, id) => {
+        return items.find(x => x.id === id);
+      }),
+    },
+  });
+
+  // assert
+  expect(store.getState().todos.getById(1)).toEqual({ id: 1, text: 'foo' });
+});
+
+it('supports multiple execution time arguments and multiple custom derived state arguments', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      countLabel: 'Count',
+      items: ['foo'],
+      count: derived(
+        [state => state.items, state => state.countLabel],
+        (items, label, runtimeArg1, runtimeArg2) =>
+          `${label}: ${items.length} ${runtimeArg1}${runtimeArg2}`,
+      ),
+    },
+  });
+
+  // assert
+  expect(store.getState().todos.count('(Rad', 'ness)')).toBe(
+    'Count: 1 (Radness)',
+  );
+});
+
+it('supports accessing state across the model', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      items: { 1: { id: 1, text: 'foo' } },
+    },
+    settings: {
+      favouriteTodoId: 1,
+      favouriteTodo: derived(
+        [
+          state => state.favouriteTodoId,
+          (state, storeState) => storeState.todos.items,
+        ],
+        (favouriteTodoId, todos) => todos[favouriteTodoId],
+      ),
+    },
+  });
+
+  // assert
+  expect(store.getState().settings.favouriteTodo()).toEqual({
+    id: 1,
+    text: 'foo',
+  });
+});
+
+it('supports accessing a derived state from another', () => {
+  // arrange
+  const store = createStore({
+    todos: {
+      items: { 1: { id: 1, text: 'foo' } },
+      getById: derived([state => state.items], (items, id) => items[id]),
+    },
+    settings: {
+      favouriteTodoId: 1,
+      favouriteTodo: derived(
+        [
+          state => state.favouriteTodoId,
+          (state, storeState) => storeState.todos.getById,
+        ],
+        (favouriteTodoId, getTodoById) => getTodoById(favouriteTodoId),
+      ),
+    },
+  });
+
+  // assert
+  expect(store.getState().settings.favouriteTodo()).toEqual({
+    id: 1,
+    text: 'foo',
+  });
+});
+
+describe('react', () => {
+  it('components are rerendered when updates occur on arguments', () => {
+    // arrange
+    let renderCount = 0;
+    function ComponentUnderTest() {
+      const count = useStore(state => state.todos.count);
+      const addTodo = useActions(actions => actions.todos.addTodo);
+      useEffect(() => {
+        renderCount += 1;
+      });
+      return (
+        <div>
+          Count: <span data-testid="count">{count()}</span>
+          <button type="button" onClick={addTodo}>
+            +
+          </button>
+        </div>
+      );
+    }
+
+    const store = createStore({
+      todos: {
+        items: [{ id: 1, text: 'foo' }],
+        count: derived([state => state.items], items => items.length),
+        addTodo: action(state => {
+          state.items.push({
+            id: 2,
+            text: 'bar',
+          });
+        }),
+      },
+      other: 'foo',
+      updateOther: action(state => {
+        state.other = 'bar';
+      }),
+    });
+
+    const app = (
+      <StoreProvider store={store}>
+        <ComponentUnderTest />
+      </StoreProvider>
+    );
+
+    // act
+    const { getByTestId, getByText } = render(app);
+
+    // assert
+    expect(renderCount).toBe(1);
+    expect(getByTestId('count').textContent).toEqual('1');
+
+    // act
+    fireEvent.click(getByText('+'));
+
+    // assert
+    expect(renderCount).toBe(2);
+    expect(getByTestId('count').textContent).toEqual('2');
+
+    // act
+    act(() => {
+      store.dispatch.updateOther();
+    });
+
+    // assert
+    expect(renderCount).toBe(2);
+  });
+
+  it('components are rerendered when global state arguments are updated', () => {
+    // arrange
+    let renderCount = 0;
+    function ComponentUnderTest() {
+      const favouriteTodo = useStore(state => state.settings.favouriteTodo);
+      useEffect(() => {
+        renderCount += 1;
+      });
+      return (
+        <div>
+          Favourite Todo:{' '}
+          <span data-testid="favourite">{favouriteTodo().text}</span>
+        </div>
+      );
+    }
+
+    const store = createStore({
+      todos: {
+        items: { 1: { id: 1, text: 'My Todo' } },
+        updateTodo: action(state => {
+          state.items['1'].text = 'Updated Todo';
+        }),
+      },
+      settings: {
+        favouriteTodoId: 1,
+        favouriteTodo: derived(
+          [
+            state => state.favouriteTodoId,
+            (state, storeState) => storeState.todos.items,
+          ],
+          (favouriteTodoId, todos) => todos[favouriteTodoId],
+        ),
+      },
+      other: 'foo',
+      updateOther: action(state => {
+        state.other = 'bar';
+      }),
+    });
+
+    const app = (
+      <StoreProvider store={store}>
+        <ComponentUnderTest />
+      </StoreProvider>
+    );
+
+    // act
+    const { getByTestId } = render(app);
+
+    // assert
+    expect(renderCount).toBe(1);
+    expect(getByTestId('favourite').textContent).toEqual('My Todo');
+
+    // act
+    act(() => {
+      store.dispatch.todos.updateTodo();
+    });
+
+    // assert
+    expect(renderCount).toBe(2);
+    expect(getByTestId('favourite').textContent).toEqual('Updated Todo');
+
+    // act
+    act(() => {
+      store.dispatch.updateOther();
+    });
+
+    // assert
+    expect(renderCount).toBe(2);
+  });
+
+  it('components are not rerendered due to state updates that are not related to the selector', () => {
+    // arrange
+    let renderCount = 0;
+    function ComponentUnderTest() {
+      const count = useStore(state => state.todos.count);
+      const addTodo = useActions(actions => actions.todos.addTodo);
+      useEffect(() => {
+        renderCount += 1;
+      });
+      return (
+        <div>
+          Count: <span data-testid="count">{count()}</span>
+          <button type="button" onClick={addTodo}>
+            +
+          </button>
+        </div>
+      );
+    }
+
+    const store = createStore({
+      todos: {
+        items: [{ id: 1, text: 'foo' }],
+        count: derived([state => state.items], items => items.length),
+        addTodo: action(state => {
+          state.items.push({
+            id: 2,
+            text: 'bar',
+          });
+        }),
+        unrelated: 'bob',
+        updateUnrelated: action(state => {
+          state.unrelated = 'qux';
+        }),
+      },
+    });
+
+    const app = (
+      <StoreProvider store={store}>
+        <ComponentUnderTest />
+      </StoreProvider>
+    );
+
+    // act
+    const { getByTestId, getByText } = render(app);
+
+    // assert
+    expect(renderCount).toEqual(1);
+    expect(getByTestId('count').textContent).toEqual('1');
+
+    // act
+    fireEvent.click(getByText('+'));
+
+    // assert
+    expect(renderCount).toEqual(2);
+    expect(getByTestId('count').textContent).toEqual('2');
+
+    // act
+    act(() => {
+      store.dispatch.todos.updateUnrelated();
+    });
+
+    // assert
+    expect(renderCount).toEqual(2);
+    expect(getByTestId('count').textContent).toEqual('2');
+  });
+});

--- a/src/__tests__/typescript/derived.ts
+++ b/src/__tests__/typescript/derived.ts
@@ -1,0 +1,73 @@
+/* eslint-disable */
+
+import { createStore, derived, Derived, Selector } from 'easy-peasy';
+
+interface Todo {
+  id: number;
+  text: string;
+}
+
+type DerivedCount = Derived<TodosModel, number, [Array<Todo>]>;
+
+interface TodosModel {
+  items: Array<Todo>;
+  count: DerivedCount;
+  getById: Derived<TodosModel, Todo | undefined, [Array<Todo>], [number]>;
+}
+
+interface StatusModel {
+  totalTodos: Derived<
+    StatusModel,
+    number,
+    [Selector<DerivedCount>],
+    void,
+    StoreModel
+  >;
+}
+
+interface StoreModel {
+  todos: TodosModel;
+  status: StatusModel;
+}
+
+const model: StoreModel = {
+  todos: {
+    items: [],
+    count: derived([state => state.items], items => {
+      return items.length;
+    }),
+    getById: derived([state => state.items], (items, id) => {
+      return items.find(x => x.id === id);
+    }),
+  },
+  status: {
+    totalTodos: derived(
+      [(state, storeState) => storeState.todos.count],
+      count => count(),
+    ),
+  },
+};
+
+const store = createStore(model);
+
+const count = store.getState().todos.count();
+
+count + 1;
+
+// typings:expect-error
+store.getState().todos.getById();
+
+// typings:expect-error
+store.getState().todos.getById('foo');
+
+const todo = store.getState().todos.getById(1);
+
+// typings:expect-error
+todo.text + 'foo';
+
+if (todo) {
+  todo.text + 'foo';
+  todo.id + 1;
+  // typings:expect-error
+  todo.id + true;
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,19 @@
-export const actionNameSymbol = '__actionName__';
-export const actionSymbol = '__action__';
-export const listenSymbol = '__listen__';
-export const metaSymbol = '__meta__';
-export const reducerSymbol = '__reducer__';
-export const selectDependenciesSymbol = '__selectDependencies__';
-export const selectImpSymbol = '__selectImp__';
-export const selectStateSymbol = '__selectState__';
-export const selectSymbol = '__select__';
-export const thunkSymbol = '__thunk__';
+export const actionNameSymbol = '🙈actionName🙈';
+export const actionSymbol = '🙈action🙈';
+
+export const derivedSymbol = '🙈derived🙈';
+export const derivedConfigSymbol = '🙈derivedConfig🙈';
+export const derivedStateSymbol = '🙈derivedState🙈';
+
+export const listenSymbol = '🙈listen🙈';
+
+export const metaSymbol = '🙈meta🙈';
+
+export const reducerSymbol = '🙈reducer🙈';
+
+export const selectDependenciesSymbol = '🙈selectDependencies🙈';
+export const selectImpSymbol = '🙈selectImp🙈';
+export const selectStateSymbol = '🙈selectState🙈';
+export const selectSymbol = '🙈select🙈';
+
+export const thunkSymbol = '🙈thunk🙈';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,8 @@
 import {
   actionNameSymbol,
   actionSymbol,
+  derivedSymbol,
+  derivedConfigSymbol,
   listenSymbol,
   reducerSymbol,
   selectDependenciesSymbol,
@@ -20,6 +22,15 @@ export const thunkFailName = action => `${action[actionNameSymbol]}(failed)`;
 
 export const action = fn => {
   fn[actionSymbol] = true;
+  return fn;
+};
+
+export const derived = (args, fn, config) => {
+  fn[derivedSymbol] = true;
+  fn[derivedConfigSymbol] = {
+    args,
+    config,
+  };
   return fn;
 };
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -5,7 +5,7 @@ import { isStateObject } from './lib';
 
 export function useStore(mapState, dependencies = []) {
   const store = useContext(EasyPeasyContext);
-  const [state, setState] = useState(mapState(store.getState()));
+  const [state, setState] = useState(() => mapState(store.getState()));
   const [error, setError] = useState(null);
   // As our effect only fires on mount and unmount it won't have the state
   // changes visible to it, therefore we use a mutable ref to track this.
@@ -37,7 +37,7 @@ export function useStore(mapState, dependencies = []) {
           return;
         }
         stateRef.current = newState;
-        setState(stateRef.current);
+        setState(() => stateRef.current);
       } catch (err) {
         // see https://github.com/reduxjs/react-redux/issues/1179
         // There is a possibility mapState will fail as the props/state that
@@ -67,6 +67,7 @@ export function useStore(mapState, dependencies = []) {
       unsubscribe();
     };
   }, dependencies);
+
   // This effect will set the ref value to indicate that the component has
   // unmounted
   useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import StoreProvider from './provider';
 import {
   action,
   actionName,
+  derived,
   listen,
   reducer,
   select,
@@ -28,6 +29,7 @@ export {
   actionName,
   createStore,
   createTypedHooks,
+  derived,
   listen,
   reducer,
   select,


### PR DESCRIPTION
This PR has been published as v2.3.0-alpha.0, under the `next` tag. You can install it like so:

```
npm install easy-peasy@next
```

Closes #175 #170 

I have some basic docs below, but they still need to be fleshed out a bit more. I will be writing docs for Typescript usage too. All of the below supports full typing too. You can look at the typescript definition tests in this branch if you are keen to see some examples.

### Intro

This PR takes all of my learnings from the current selector API and introduces a new derived state alternative API, named `derived`, that attempts to resolve the problems and limitations that I identified with the `select` helper.

When this gets merged, the `select` API will be marked as deprecated. Any use of it will output a warning message, advising that existing implementations migrate to the new helper. 

When the next major release of `easy-peasy` happens we will then remove the deprecated `select` helper.

### Documentation

The new `derived` helper is intended to allow you to derive state based on your existing state. It performs memoization under the hood and only attempts to resolve the derived state again when the inputs to the selector change.

**Simple Example**

Firstly, we will demonstrate a very straight forward implementation.

```javascript
import { derived } from 'easy-peasy';

const store = createStore({
  todos: {
    items: [],
    count: derived(
      // The first argument to derived requires you to provide an array of
      // "argument selectors". These "argument selectors" are functions that
      // will take in the state of the model they are bound against, and will
      // return the part of the state required by your derived state selector.
      // The results of each of the "argument selectors" become the arguments
      // to your derived state selector.
      [(state) => state.items], 
      
      // Now you defined your selector. It receives the arguments, which are 
      // a result of your argument selectors above.
      // You then return the derived state based on the arguments
      (items) => items.length,
    }),
  }
});
```

The above is slightly more verbose than the `select` API, however, by forcing you to first select the parts of your model your derived state selector cares about (via the "argument selectors") we are able to provide much better performance characteristics for you.

Consumption of your derived state has also changed. You no longer get the derived state directly available via the `useStore` hook. Instead a function is exposed at the same path allowing you to request the derived state.

For example:

```javascript
import { useStore } from 'easy-peasy';

function TotalTodos() {
  const todoCount = useStore(state => state.todos.count);
  // Notice how we execute the todoCount below:
  //                       👇
  return <div>Total: {todoCount()}</div>;
}
```

There are a few reasons we have moved to this API design:

1. It provides us with much improved performance characteristics, as derived state selectors will only be resolved/executed on demand - and will subsequently be cached, with the cached result available to any subsequent use of the derived state within your app.
2. It opens up the opportunity for us to support "runtime arguments" to your derived state selectors - I will explain this further below.

Also, be aware, that your component will rerender if changes are made to the underlying state that your derived state selector depends on. So in our example above our component would rerender if a todo item was added or removed. Our component will only rerender in this condition - no other state updates to the todos model or other parts of your store will cause any rerender.

**Accessing global state from your "argument selectors"**

A fairly common request we have had was the ability to select across different branches of your model. With the `select` helper this was very hard to do, especially in a performant manner. The new `derived` helper provides a simple API, with optimisation characteristics that match using local state.

```javascript
const store = createStore({
  todos: {
    items: {
      1: { id: 1, text: 'Win the lottery' ]
    }
  },
  profile: {
    favouriteTodoId: 1,
    favouriteTodo: derived(
     // Notice how we are providing multiple "argument selectors" now
     [
       (state) => state.favouriteTodoId,
       // Our argument selectors receive as a second argument the entire
       // store state
       (_, storeState) => storeState.todos.items
     ],
     // We receive both our argument selectors and do the derived state
     (todoId, todos) => todos[todoId]
    )
  }
});
```

**Example of runtime arguments within your derived state**

Your derived state helpers support runtime arguments. Any arguments that are provided to your derived state selector during access will be passed into it. This is best illustrated with an example.

```javascript
const store = createStore({
  todos: {
    items: {
      1: { id: 1, text: 'Win the lottery' ]
    },
    getById: derived(
      [(state) => state.items], 
      // Note this second argument. It wasn't defined above. We therefore
      // expect it to be provided at runtime
      //      👇
      (items, id) => items[id]
  },
});
```

And here is an example using it:

```javascript
import { useStore } from 'easy-peasy';

function Todo({ id }) {
  const getTodoById = useStore(state => state.todos.getById);
  // Notice how we provide the runtime argument
  //                       👇
  const todo = getTodoById(id);
  return todo ? <div>{todo.text}</div> : null;
}
```

**Customising the cache limit for derived state (especially helpful when runtime args used)** 

By default the derived state has a cache limit of 1. This means that if you provide a new runtime argument every time you hit your derived state helper it will be run.

Typically when you are introducing a derived state selector that consumes runtime arguments you will want to customise the cache limit. Imagine rendering a list of todos, where you called the `getTodoById` multiple times with each id. You certainly want to have at least a deeper limit of caching to support this and avoid unnecessary re-renders.

You can easily customise the cache limit via the 3rd argument to the `derived` helper. The config object.

```javascript
const store = createStore({
  todos: {
    items: {
      1: { id: 1, text: 'Win the lottery' ]
    },
    getById: derived(
      [(state) => state.items], 
      (items, id) => items[id],
      // We will cache the most recent 100 unique calls to 
      // our selector based on the runtime arguments
      //        👇
      { limit: 100 }
  },
});
```

**Derived state selectors referencing each other**

You can reference selectors from any part of your tree when defining one. It follows much of the same principals as consuming other state.

```javascript
const store = createStore({
  todos: {
    items: {
      1: { id: 1, text: 'Win the lottery' ]
    },
    getById: derived(
      [(state) => state.items], 
      (items, id) => items[id],
      { limit: 100 }
  },
  },
  profile: {
    favouriteTodoId: 1,
    favouriteTodo: derived(
     // Notice how we are providing multiple "argument selectors" now
     [
       (state) => state.favouriteTodoId,
       // Here we pull a reference to the other derived state selector
       (_, storeState) => storeState.todos.getById
     ],
     // We receive both our argument selectors and execute the received
     // derived state selector
     (todoId, getTodoById) => getTodoById(todoId)
    )
  }
});
```

### Final Notes

Some tips when using this feature:

1. Keep your "argument selectors" simple. They should simply return the bits of state that you care about. Do all the mapping and deep property accessing within the selector function itself - you will generally experience improved performance compared to doing complex selections within your "argument selectors".