### PR TITLE
Add Sandbox link for Typescript Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ You're off to the races.
 
 ### Easy Peasy Typescript
 
+[Open in Sandbox](https://codesandbox.io/s/github/ctrlplusb/easy-peasy-typescript)
+
 This GitHub repository shows off how to utilise Typescript with Easy Peasy. I highly recommend cloning it and running it so that you can experience first hand what a joy it is to have types helping you with global state.
 
 https://github.com/ctrlplusb/easy-peasy-typescript


### PR DESCRIPTION
I didn't want to clone and run the TypeScript demo and tried opening it from Github repo. It would be easier for people to test it out with only clicking a link.