### PR TITLE
Fix example for defining-computed-properties

### DIFF
--- a/website/docs/docs/tutorial/defining-computed-properties.md
+++ b/website/docs/docs/tutorial/defining-computed-properties.md
@@ -13,7 +13,7 @@ const store = createStore({
     products: [{ name: 'Shoes', price: 123 }, { name: 'Hat', price: 75 }],
     //            👇 define the computed property
     totalPrice: computed(state =>
-      products.reduce((acc, cur) => acc + cur.price, 0)
+      state.products.reduce((acc, cur) => acc + cur.price, 0)
     )
   }
 }


### PR DESCRIPTION
The docs example is missing the `state` object for `products`, i.e.: `products.reduce(...)` -> `state.products.reduce(...)`