### PR TITLE
HTML suffix to store links within docs

### DIFF
--- a/website/docs/docs/api/computed.md
+++ b/website/docs/docs/api/computed.md
@@ -124,7 +124,7 @@ function TotalPriceOfProducts() {
 
 ## Accessing via the store instance
 
-You can also access the computed property via the [store's](/docs/api/store) `getState` API.
+You can also access the computed property via the [store's](/docs/api/store.html) `getState` API.
 
 ```javascript
 console.log(store.getState().products.totalPrice);

--- a/website/docs/docs/api/use-store-actions.md
+++ b/website/docs/docs/api/use-store-actions.md
@@ -1,6 +1,6 @@
 # useStoreActions
 
-A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store) [actions](/docs/api/action.html).
+A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store.html) [actions](/docs/api/action.html).
 
 ```javascript
 const addTodo = useStoreActions(actions => actions.todos.add);

--- a/website/docs/docs/api/use-store-dispatch.md
+++ b/website/docs/docs/api/use-store-dispatch.md
@@ -1,6 +1,6 @@
 # useStoreDispatch
 
-A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store) dispatch.
+A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store.html) dispatch.
 
 ```javascript
 const dispatch = useStoreDispatch();

--- a/website/docs/docs/api/use-store-state.md
+++ b/website/docs/docs/api/use-store-state.md
@@ -1,6 +1,6 @@
 # useStoreState
 
-A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store) state.
+A [hook](https://reactjs.org/docs/hooks-intro.html) granting your components access to the [store's](/docs/api/store.html) state.
 
 ```javascript
 const todos = useStoreState(state => state.todos.items);

--- a/website/docs/docs/recipes/hot-reloading.md
+++ b/website/docs/docs/recipes/hot-reloading.md
@@ -25,6 +25,6 @@ if (process.env.NODE_ENV === "development") {
 export default store;
 ```
 
-Note how you can call the [store's](/docs/api/store) `reconfigure` method in order to reconfigure the store with your updated model. The existing state will be maintained.
+Note how you can call the [store's](/docs/api/store.html) `reconfigure` method in order to reconfigure the store with your updated model. The existing state will be maintained.
 
 You can [view a demo repository configured for hot reloading here](https://github.com/ctrlplusb/easy-peasy-hot-reload).

--- a/website/docs/docs/testing/testing-thunks.md
+++ b/website/docs/docs/testing/testing-thunks.md
@@ -15,7 +15,7 @@ Within either of these strategies your thunks may perform side effects such as m
 
 The `createStore` API contains a configuration property named `mockActions`, which if set to `true`, will ensure that any action that is dispatched will not be executed, and will instead be recorded - along with their payloads. You can then access the recorded actions via the `getMockedActions` function that is available on the store instance. 
 
-> We took inspiration for this strategy from the awesome [`redux-mock-store`](https://github.com/dmitry-zaets/redux-mock-store) package.
+> We took inspiration for this strategy from the awesome [`redux-mock-store`](https://github.com/dmitry-zaets/redux-mock-store.html) package.
 
 Given the following model under test:
 

--- a/website/docs/docs/tutorial/consuming-state.md
+++ b/website/docs/docs/tutorial/consuming-state.md
@@ -100,7 +100,7 @@ This is another example of our `mapState` function performing some state derivin
 
 ## A note on optimisation
 
-Under the hood the [useStoreState](/docs/api/use-store-state.html) will execute its `mapState` function any time an update to your [store's](/docs/api/store) state occurs. It will then check the result of the newly mapped state against the previously mapped state using strict equality (`===`) checking.
+Under the hood the [useStoreState](/docs/api/use-store-state.html) will execute its `mapState` function any time an update to your [store's](/docs/api/store.html) state occurs. It will then check the result of the newly mapped state against the previously mapped state using strict equality (`===`) checking.
 
 If the newly mapped state ***is not equal*** to the previously mapped state (`nextMappedState !== prevMappedState`) your component will be rendered, receiving the new value. If the newly mapped state ***is equal*** to the previously mapped state (`nextMappedState === prevMappedState`) no render will occur.
 
@@ -126,7 +126,7 @@ This performance pitfall is described within the [useStoreState](/docs/api/use-s
 
 ## Review
 
-Awesome sauce, our components are hooked up to our [store's](/docs/api/store) state! As amazing as that is, our application is essentially static right now, with no ability to update our [store's](/docs/api/store) state.
+Awesome sauce, our components are hooked up to our [store's](/docs/api/store.html) state! As amazing as that is, our application is essentially static right now, with no ability to update our [store's](/docs/api/store.html) state.
 
 In the next section we'll look into how we can use [actions](/docs/api/action.html) in order to support updates.
 

--- a/website/docs/docs/typescript-tutorial/create-your-store.md
+++ b/website/docs/docs/typescript-tutorial/create-your-store.md
@@ -1,6 +1,6 @@
 # Creating your store
 
-The heart of the TypeScript integration with Easy Peasy are the typing definitions you define to represent your [store's](/docs/api/store) model. This typing information can then be used by the various Easy Peasy APIs to provide you with assertions, code completions, etc.
+The heart of the TypeScript integration with Easy Peasy are the typing definitions you define to represent your [store's](/docs/api/store.html) model. This typing information can then be used by the various Easy Peasy APIs to provide you with assertions, code completions, etc.
 
 For this tutorial we will create a model consisting of two slices; todos and an audit log.
 
@@ -80,7 +80,7 @@ import storeModel from './model';
 const store = createStore(storeModel);
 ```
 
-The [store](/docs/api/store.html) that is returned will be fully typed. If you try to use the [store's](/docs/api/store) APIs you will note the typing information and code completion being offered by your IDE.
+The [store](/docs/api/store.html) that is returned will be fully typed. If you try to use the [store's](/docs/api/store.html) APIs you will note the typing information and code completion being offered by your IDE.
 
 <div class="screenshot">
   <img src="../../assets/typescript-tutorial/typed-get-state.png" />


### PR DESCRIPTION
Without those extensions, various places point to `https://easy-peasy.now.sh/docs/api/store` (no `.html` suffix), which results in 404.

Related docs: https://v1.vuepress.vuejs.org/guide/markdown.html#links