### PR TITLE
reduce the number of mapped types used in state mapper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -215,13 +215,18 @@ type RecursiveState<
   Depth extends string
 > = Depth extends '6'
   ? Model
-  : O.Merge<
-      StateMapper<
-        O.Omit<O.Filter<Model, ActionTypes>, IndexSignatureKeysOfType<Model>>,
-        Depth
-      >,
-      O.Pick<Model, IndexSignatureKeysOfType<Model>>
-    >;
+  : {
+    [K in keyof O.Filter<Model, ActionTypes>]: K extends IndexSignatureKeysOfType<Model>
+      ? Model[K]
+      : StateMapper<{ 0: Model[K] }, Depth>[0]
+  }
+  // : O.Merge<
+  //     StateMapper<
+  //       O.Omit<O.Filter<Model, ActionTypes>, IndexSignatureKeysOfType<Model>>,
+  //       Depth
+  //     >,
+  //     O.Pick<Model, IndexSignatureKeysOfType<Model>>
+  //   >;
 
 /**
  * Filters a model into a type that represents the state only (i.e. no actions)


### PR DESCRIPTION
Working proposal on #227, not patch quality at this point.

My exact manifestation is:
 - Typescript 3.5.3 and 3.6.3
 - Problem only appears in the state mapper (actions, listeners are fine).
 - Reducing the recursion depth to 4 from the original 6 clears the error (suggesting ~10-12 levels of mapped types per recursion).
 - Error appears inconsistently between VSCode inline errors and CRA build process.

The typescript compiler has a hard instantiation depth limit of 50, as explained here:
https://github.com/microsoft/TypeScript/issues/31619
The TS team considers this "as designed". 

I haven't been able to create a standalone example to replicate the issue, but the patch below eliminates it in my environment. The intent is to reduce the number of type instantiations by replacing the elegant (but complex) `ts-toolbelt` based type mapper with a simpler alternative. I haven't done exhaustive model tests, but the code below seems to provide the same behavior as the original implementation, with a maximum of 3 levels of mapped types per recursion.

