### PR TITLE
Prevent state updates on unmounted components

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -23,6 +23,7 @@ export function createStoreStateHook(Context) {
     const store = useContext(Context);
     const mapStateRef = useRef(mapState);
     const stateRef = useRef();
+    const mountedRef = useRef(true);
     const subscriptionMapStateError = useRef();
 
     const [, forceRender] = useReducer(s => s + 1, 0);
@@ -63,11 +64,16 @@ export function createStoreStateHook(Context) {
           // component to update. It should then receive the updated state
           subscriptionMapStateError.current = err;
         }
-        forceRender({});
+        if (mountedRef.current) {
+          forceRender({});
+        }
       };
       const unsubscribe = store.subscribe(checkMapState);
       checkMapState();
-      return unsubscribe;
+      return () => {
+        mountedRef.current = false;
+        unsubscribe();
+      };
     }, []);
 
     return stateRef.current;


### PR DESCRIPTION
Fixes issue (#306) that occurs under the following conditions:

 1. A piece of store state is modified.
 2. The state modification causes component(s) to unmount.
 3. One or more of the unmounted components is watching the modified state from 1 via a `useStoreState` hook.
 4. The `useStoreState` hook detects the watched state change and attempts to re-render the unmounted component.

I found this problem (along with the OP of #306) in authenticated user tracking: protected routes unmount without a logged in user, while the routes themselves use the user identity from the store.

The root cause here is that `redux` does not guarantee subscription changes during a dispatch cycle. The `useStoreState` hook is unsubscribed from the store as it is unmounted, but it still receives the state change notification due to a stale subscription.

Fix:
 - Use a ref to mark the hook as unmounted during unsubscribe.
 - Suppress the component update if unmounted.