### PR TITLE
feat: Returning falsey value from a thunk will not throw or reject

### DIFF
--- a/src/__tests__/thunks.test.js
+++ b/src/__tests__/thunks.test.js
@@ -45,6 +45,106 @@ test('dispatches actions to represent a succeeded thunk', () => {
   expect(actualResult).toBe('did something');
 });
 
+test('returning falsey from thunk', () => {
+  // arrange
+  const model = {
+    foo: {
+      doSomething: thunk(() => {
+        return false;
+      }),
+    },
+  };
+  const trackActions = trackActionsMiddleware();
+  const store = createStore(model, { middleware: [trackActions] });
+  const payload = 'a payload';
+
+  // act
+  const res = store.getActions().foo.doSomething(payload);
+
+  // assert
+  expect(trackActions.actions).toEqual([
+    { type: '@thunk.foo.doSomething(start)', payload },
+    {
+      type: '@thunk.foo.doSomething(fail)',
+      payload,
+      error: false,
+    },
+    {
+      type: '@thunk.foo.doSomething',
+      payload,
+      error: false,
+    },
+  ]);
+
+  expect(res).toBe(false);
+});
+
+test('returning nothing or undefined from thunk', () => {
+  // arrange
+  const model = {
+    foo: {
+      doSomething: thunk(() => {}),
+    },
+  };
+  const trackActions = trackActionsMiddleware();
+  const store = createStore(model, { middleware: [trackActions] });
+  const payload = 'a payload';
+
+  // act
+  const res = store.getActions().foo.doSomething(payload);
+
+  // assert
+  expect(trackActions.actions).toEqual([
+    { type: '@thunk.foo.doSomething(start)', payload },
+    {
+      type: '@thunk.foo.doSomething(success)',
+      payload,
+      result: undefined,
+    },
+    {
+      type: '@thunk.foo.doSomething',
+      payload,
+      result: undefined,
+    },
+  ]);
+
+  expect(res).toBe(undefined);
+});
+
+test('returning truthy from thunk', () => {
+  // arrange
+  const model = {
+    foo: {
+      doSomething: thunk(() => {
+        return true;
+      }),
+    },
+  };
+  const trackActions = trackActionsMiddleware();
+  const store = createStore(model, { middleware: [trackActions] });
+  const payload = 'a payload';
+
+  // act
+  const res = store.getActions().foo.doSomething(payload);
+
+  // assert
+  expect(trackActions.actions).toEqual([
+    { type: '@thunk.foo.doSomething(start)', payload },
+    {
+      type: '@thunk.foo.doSomething(success)',
+      payload,
+      result: true,
+    },
+    {
+      type: '@thunk.foo.doSomething',
+      payload,
+      result: true,
+    },
+  ]);
+
+  expect(res).toBe(true);
+});
+
 describe('errors', () => {
   test('dispatches actions to represent a failed thunk', async () => {
     // arrange

--- a/src/thunks.js
+++ b/src/thunks.js
@@ -89,7 +89,11 @@ export function createThunkActionsCreator(
             throw err;
           });
       }
-      dispatchSuccess(result);
+      if (typeof result === 'undefined') {
+        dispatchSuccess(result);
+      } else {
+        result ? dispatchSuccess(result) : dispatchError(result);
+      }
       return result;
     } catch (err) {
       dispatchError(err);


### PR DESCRIPTION
There are times when I do not want to throw an error or reject a Promise. For example, I may have already handled a specific error scenario and want to do that within the thunk itself. I could handle the error within my components, but that means I would have to do so in every component that calls the thunk.

Currently, a thunk must return a promise or throw an error to ensure that all easy-peasy listeners are triggered. So if I catch any error in the thunk and not re-throw, the failType listeners will not be triggered.

This PR simply allows you to return a truthy/falsey value from your thunks, and supports its existing functionality.

If you return a truthy value, the thunk will be a success, and if you return a falsey value, then  the thunk will be a failure. And this results in the expected listeners being triggered.

As an example:

```javascript
users: thunk(async () => {
  try {
    await fetch('/users')
  } catch (error) {
    if (error.response.status === 404) {
      return false
    } else {
      throw error
    }
  }
})
```

The above will catch any 404 and return false but not throw or reject a promise. Otherwise, the original error is thrown.