### PR TITLE
update docs for store

### DIFF
--- a/website/docs/docs/api/store.md
+++ b/website/docs/docs/api/store.md
@@ -34,7 +34,7 @@ A store is created via the [createStore](/docs/api/create-store.html) API. A sto
 
     If the `mockActions` configuration value was passed to the `createStore` then calling this function will return the actions that have been dispatched (and mocked). This is useful in the context of testing - especially thunks and listeners.
 
-  - `getState` (Function, required)
+  - `getState` (Function)
 
     Returns the state of your store.
 


### PR DESCRIPTION
I don't see any reason to include `required` here - maybe a copy-paste remnant?