### PR TITLE
feat: Lazy models [WIP]

### DIFF
--- a/src/create-context-store.js
+++ b/src/create-context-store.js
@@ -1,10 +1,12 @@
 /* eslint-disable react/prop-types */
 
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useMemo } from 'react';
 import {
   createStoreActionsHook,
   createStoreDispatchHook,
   createStoreStateHook,
+  createStoreHook,
+  createStoreModelHook,
   createStoreRehydratedHook,
 } from './hooks';
 import createStore from './create-store';
@@ -26,16 +28,13 @@ export default function createContextStore(model, config) {
     );
   }
 
-  function useStore() {
-    return useContext(StoreContext);
-  }
-
   return {
     Provider,
-    useStore,
+    useStore: createStoreHook(StoreContext),
     useStoreState: createStoreStateHook(StoreContext),
     useStoreActions: createStoreActionsHook(StoreContext),
     useStoreDispatch: createStoreDispatchHook(StoreContext),
     useStoreRehydrated: createStoreRehydratedHook(StoreContext),
+    useStoreModel: createStoreModelHook(StoreContext),
   };
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -111,9 +111,13 @@ export function createStoreDispatchHook(Context) {
 
 export const useStoreDispatch = createStoreDispatchHook(EasyPeasyContext);
 
-export function useStore() {
-  return useContext(EasyPeasyContext);
+export function createStoreHook(Context) {
+  return function useStore() {
+    return useContext(Context);
+  };
 }
+
+export const useStore = createStoreHook(EasyPeasyContext);
 
 export function createStoreRehydratedHook(Context) {
   return function useStoreRehydrated() {
@@ -126,6 +130,26 @@ export function createStoreRehydratedHook(Context) {
   };
 }
 
+export function createStoreModelHook(Context) {
+  return function useStoreModel(model) {
+    const store = useContext(Context);
+    const modelRef = useRef(model);
+
+    useEffect(() => {
+      Object.entries(modelRef.current).forEach(([key, value]) =>
+        store.addModel(key, value),
+      );
+
+      return () =>
+        Object.entries(modelRef.current).forEach(([key, value]) =>
+          store.removeModel(key, value),
+        );
+    }, [store]);
+  };
+}
+
+export const useStoreModel = createStoreModelHook(EasyPeasyContext);
+
 export const useStoreRehydrated = createStoreRehydratedHook(EasyPeasyContext);
 
 export function createTypedHooks() {
@@ -134,6 +158,7 @@ export function createTypedHooks() {
     useStoreDispatch,
     useStoreState,
     useStoreRehydrated,
+    useStoreModel,
     useStore,
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,14 @@ import {
   useStoreDispatch,
   useStoreState,
   useStoreRehydrated,
+  useStoreModel,
   useStore,
 } from './hooks';
 import createStore from './create-store';
 import createContextStore from './create-context-store';
 import createComponentStore from './create-component-store';
 import createTransform from './create-transform';
-import StoreProvider from './provider';
+import Store from './store';
 import {
   action,
   actionOn,
@@ -29,6 +30,8 @@ import {
  * explicitly disabled it to avoid perf issues.
  */
 setAutoFreeze(false);
+
+const StoreProvider = Store.Provider; // @deprecated backwards compatibility
 
 export {
   action,
@@ -50,5 +53,7 @@ export {
   useStoreDispatch,
   useStoreState,
   useStoreRehydrated,
+  useStoreModel,
   useStore,
+  Store,
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,13 @@
+import Provider from './provider';
+import { useStoreModel } from './hooks';
+
+const Model = ({ model, children }) => {
+  useStoreModel(model);
+
+  return children;
+};
+
+export default {
+  Provider,
+  Model,
+};


### PR DESCRIPTION
following the approach detailed [https://github.com/ctrlplusb/easy-peasy/issues/410](url)

**Added**
 - useStoreModel hook
 - Store.Model wrapper component for a declarative approach

**TODO**
Tests

**Possible issues**
the usage of this new API on context stores might give some headaches if my proposal for runtime injections for context stores gets eventually merged, need to think about that...

@ctrlplusb 
 - Should this be available on context stores aswell?
 - Backwards compatibility with V3 so no need to wait for 4.0 :)
