### PR TITLE
feat: Runtime StoreConfig for Context/Local stores [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "debounce": "^1.2.0",
     "immer-peasy": "3.1.3",
     "is-plain-object": "^3.0.0",
+    "lodash.merge": "^4.6.2",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.6.2",
     "redux": "^4.0.5",

--- a/src/__tests__/create-component-store.test.js
+++ b/src/__tests__/create-component-store.test.js
@@ -1,6 +1,9 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable no-shadow */
+
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { createComponentStore, action } from '../index';
+import { createComponentStore, action, thunk, actionOn } from '../index';
 
 const useCounter = createComponentStore({
   count: 0,
@@ -114,4 +117,103 @@ it('with initial data', () => {
 
   // assert
   expect(count.firstChild.textContent).toBe('2');
+});
+
+it('with runtime injection', () => {
+  // arrange
+  const useCounter = createComponentStore(data => ({
+    count: data.count || 0,
+    getNext: thunk((actions, payload, { getState, injections }) =>
+      injections.next(getState().count),
+    ),
+    onNext: actionOn(
+      actions => actions.getNext.successType,
+      (state, { result }) => {
+        state.count = result;
+      },
+    ),
+  }));
+
+  function CountDisplay({ next }) {
+    const [state, actions] = useCounter({ count: 4 }, { next });
+    return (
+      <>
+        <div data-testid="count">{state.count}</div>
+        <button data-testid="button" onClick={actions.getNext} type="button">
+          fetch next
+        </button>
+      </>
+    );
+  }
+
+  const multiplier = value => value * 2;
+
+  const app = <CountDisplay next={multiplier} />;
+
+  // act
+  const { getByTestId } = render(app);
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  // assert
+  expect(count.firstChild.textContent).toBe('4');
+
+  // act
+  fireEvent.click(button);
+
+  // assert
+  expect(count.firstChild.textContent).toBe('8');
+});
+
+it('with state preservation when updating runtime injection', () => {
+  // arrange
+  const useCounter = createComponentStore(data => ({
+    count: data.count || 0,
+    getNext: thunk((actions, payload, { getState, injections }) =>
+      injections.next(getState().count),
+    ),
+    onNext: actionOn(
+      actions => actions.getNext.successType,
+      (state, { result }) => {
+        state.count = result;
+      },
+    ),
+  }));
+
+  function CountDisplay({ next }) {
+    const [state, actions] = useCounter({ count: 4 }, { next });
+    return (
+      <>
+        <div data-testid="count">{state.count}</div>
+        <button data-testid="button" onClick={actions.getNext} type="button">
+          fetch next
+        </button>
+      </>
+    );
+  }
+
+  const getComponent = next => <CountDisplay next={next} />;
+
+  const multiplier = value => value * 2;
+
+  // act
+  const { getByTestId, rerender } = render(getComponent(multiplier));
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  expect(count.firstChild.textContent).toBe('4');
+
+  fireEvent.click(button);
+
+  expect(count.firstChild.textContent).toBe('8');
+
+  const plusOne = value => value + 1;
+
+  rerender(getComponent(plusOne));
+
+  fireEvent.click(button);
+
+  expect(count.firstChild.textContent).toBe('9');
 });

--- a/src/__tests__/create-context-store.test.js
+++ b/src/__tests__/create-context-store.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { createContextStore, action } from '../index';
+import { createContextStore, action, thunk, actionOn } from '../index';
 
 const Counter = createContextStore({
   count: 0,
@@ -142,4 +142,119 @@ it('with initial data', () => {
 
   // assert
   expect(count.firstChild.textContent).toBe('2');
+});
+
+it('with runtime injection', () => {
+  // arrange
+  const Counter = createContextStore(data => ({
+    count: data.count || 0,
+    getNext: thunk((actions, payload, { getState, injections }) =>
+      injections.next(getState().count),
+    ),
+    onNext: actionOn(
+      actions => actions.getNext.successType,
+      (state, { result }) => {
+        state.count = result;
+      },
+    ),
+  }));
+
+  function CountDisplay() {
+    const count = Counter.useStoreState(state => state.count);
+    const getNext = Counter.useStoreActions(actions => actions.getNext);
+    return (
+      <>
+        <div data-testid="count">{count}</div>
+        <button data-testid="button" onClick={getNext} type="button">
+          fetch next
+        </button>
+      </>
+    );
+  }
+
+  const multiplier = value => value * 2;
+
+  const app = (
+    <Counter.Provider
+      initialData={{ count: 4 }}
+      config={{ injections: { next: multiplier } }}
+    >
+      <CountDisplay />
+    </Counter.Provider>
+  );
+
+  // act
+  const { getByTestId } = render(app);
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  // assert
+  expect(count.firstChild.textContent).toBe('4');
+
+  // act
+  fireEvent.click(button);
+
+  // assert
+  expect(count.firstChild.textContent).toBe('8');
+});
+
+it('with state preservation when updating runtime injection', () => {
+  // arrange
+  const Counter = createContextStore(data => ({
+    count: data.count || 0,
+    getNext: thunk((actions, payload, { getState, injections }) =>
+      injections.next(getState().count),
+    ),
+    onNext: actionOn(
+      actions => actions.getNext.successType,
+      (state, { result }) => {
+        state.count = result;
+      },
+    ),
+  }));
+
+  function CountDisplay() {
+    const count = Counter.useStoreState(state => state.count);
+    const getNext = Counter.useStoreActions(actions => actions.getNext);
+
+    return (
+      <>
+        <div data-testid="count">{count}</div>
+        <button data-testid="button" onClick={getNext} type="button">
+          fetch next
+        </button>
+      </>
+    );
+  }
+
+  const getComponent = next => (
+    <Counter.Provider
+      initialData={{ count: 4 }}
+      config={{ injections: { next } }}
+    >
+      <CountDisplay />
+    </Counter.Provider>
+  );
+
+  const multiplier = value => value * 2;
+
+  // act
+  const { getByTestId, rerender } = render(getComponent(multiplier));
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  expect(count.firstChild.textContent).toBe('4');
+
+  fireEvent.click(button);
+
+  expect(count.firstChild.textContent).toBe('8');
+
+  const plusOne = value => value + 1;
+
+  rerender(getComponent(plusOne));
+  fireEvent.click(button);
+
+  expect(count.firstChild.textContent).toBe('9');
 });

--- a/src/create-context-store.js
+++ b/src/create-context-store.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/prop-types */
 
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useRef, useEffect } from 'react';
+import produce from 'immer-peasy';
+import merge from 'lodash.merge';
 import {
   createStoreActionsHook,
   createStoreDispatchHook,
@@ -9,20 +11,61 @@ import {
 } from './hooks';
 import createStore from './create-store';
 
-export default function createContextStore(model, config) {
+const shouldRecreateStoreOnInjectionsChange = (prevProps, currentProps) => {
+  if (!prevProps && currentProps.config) return true;
+  if (prevProps && prevProps.config && currentProps && currentProps.config) {
+    const prevInjections = prevProps.config.injections || {};
+    const currInjections = currentProps.config.injections || {};
+    const mergedInjections = { ...currInjections, ...prevInjections };
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of Object.keys(mergedInjections)) {
+      if (currInjections[key] !== mergedInjections[key]) return true;
+    }
+    return false;
+  }
+  return currentProps && currentProps.config;
+};
+
+export default function createContextStore(model, config = {}) {
   const StoreContext = createContext();
 
-  function Provider({ children, initialData }) {
-    const store = useMemo(
-      () =>
-        createStore(
-          typeof model === 'function' ? model(initialData) : model,
-          config,
-        ),
-      [],
-    );
+  function Provider({ children, initialData, ...props }) {
+    const {
+      config: runtimeConfig,
+      shouldRecreateStore = shouldRecreateStoreOnInjectionsChange,
+      configMergeStrategy = merge,
+    } = props;
+
+    const previousPropsRef = useRef();
+    const storeRef = useRef();
+    const previousStateRef = useRef();
+
+    if (
+      !storeRef.current ||
+      shouldRecreateStore(previousPropsRef.current, props)
+    ) {
+      storeRef.current = createStore(
+        typeof model === 'function' ? model(initialData) : model,
+        produce(config, draft => {
+          configMergeStrategy(draft, runtimeConfig);
+          if (previousStateRef.current)
+            draft.initialState = previousStateRef.current;
+        }),
+      );
+    }
+
+    previousPropsRef.current = props;
+
+    useEffect(() => {
+      return storeRef.current.subscribe(() => {
+        previousStateRef.current = storeRef.current.getState();
+      });
+    }, [storeRef.current]);
+
     return (
-      <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
+      <StoreContext.Provider value={storeRef.current}>
+        {children}
+      </StoreContext.Provider>
     );
   }
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -24,7 +24,7 @@ export function createStoreStateHook(Context) {
     const store = useContext(Context);
     const mapStateRef = useRef(mapState);
     const stateRef = useRef();
-    const mountedRef = useRef(true);
+    const mountedRef = useRef();
     const subscriptionMapStateError = useRef();
 
     const [, forceRender] = useReducer(s => s + 1, 0);
@@ -80,12 +80,13 @@ export function createStoreStateHook(Context) {
         }
       };
       const unsubscribe = store.subscribe(checkMapState);
+      mountedRef.current = true;
       checkMapState();
       return () => {
         mountedRef.current = false;
         unsubscribe();
       };
-    }, []);
+    }, [store]);
 
     return stateRef.current;
   };


### PR DESCRIPTION
same as [https://github.com/ctrlplusb/easy-peasy/pull/392](url)

just cleaned my fork so I could work on different things... :)

I think the last experiments added lots of complexity...

@ctrlplusb 
Maybe rollback to just injections and possibly name configuration... and drop the shouldRecreateStore and configMergeStrategy proposals?

What are your current thoughts on this?