### PR TITLE
fix localStorage error when in iframe

### DIFF
--- a/src/persistence.js
+++ b/src/persistence.js
@@ -8,15 +8,22 @@ const noopStorage = {
   removeItem: () => undefined,
 };
 
-const localStorage =
-  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
-    ? window.localStorage
-    : noopStorage;
+function getStorage(storageName) {
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window[storageName] !== 'undefined'
+    ) {
+      return window[storageName];
+    }
+    return noopStorage;
+  } catch (_) {
+    return noopStorage;
+  }
+}
 
-const sessionStorage =
-  typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined'
-    ? window.sessionStorage
-    : noopStorage;
+const localStorage = getStorage('localStorage');
+const sessionStorage = getStorage('sessionStorage');
 
 function createStorageWrapper(storage = sessionStorage, transformers = []) {
   if (typeof storage === 'string') {


### PR DESCRIPTION
When embedding an easy-peasy app in iframe some users are getting errors because of their 3rd party cookie settings (https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni). This can be fixed by wrapping the localStorage and sessionStorage getter into a try catch block.