### PR TITLE
fix typo: website -> docs -> quick-start.md

### DIFF
--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -212,7 +212,7 @@ const auditModel = {
     (actions, storeActions) => storeActions.basket.addProduct,
     // action handler that executes when target is executed:
     (state, target) => {
-      state.logs(`Added product ${target.payload} to basket`);
+      state.logs.push(`Added product ${target.payload} to basket`);
     },
   )
 }


### PR DESCRIPTION
url in website: https://easy-peasy.now.sh/docs/quick-start.html#action-thunk-listeners

should be 'state.logs.**push**(`Added product ${target.payload} to basket`)'  

it seems that 'push' is lost accidentally.