### PR TITLE
fixes computed error when get() returns undefined

### DIFF
--- a/src/__tests__/dynamic-store.test.js
+++ b/src/__tests__/dynamic-store.test.js
@@ -1,4 +1,4 @@
-import { action, createStore } from '../index';
+import { action, createStore, computed } from '../index';
 
 test('addModel', () => {
   // arrange
@@ -17,10 +17,14 @@ test('addModel', () => {
     push: action((state, payload) => {
       state.path = payload;
     }),
+    url: computed(state => name => {
+      return `${state.path}${name}`;
+    }),
   });
 
   // assert
   expect(store.getState().router.path).toBe('/');
+  expect(store.getState().router.url('home')).toBe('/home');
 
   // act
   store.getActions().router.push('/foo');

--- a/src/create-reducer.js
+++ b/src/create-reducer.js
@@ -48,7 +48,7 @@ export default function createReducer(
     if (state !== next) {
       computedProperties.forEach(({ parentPath, bindComputedProperty }) => {
         const prop = get(parentPath, next);
-        if (prop) bindComputedProperty(prop);
+        if (prop != null) bindComputedProperty(prop);
       });
     }
     return next;

--- a/src/create-reducer.js
+++ b/src/create-reducer.js
@@ -47,7 +47,8 @@ export default function createReducer(
         : stateAfterActions;
     if (state !== next) {
       computedProperties.forEach(({ parentPath, bindComputedProperty }) => {
-        bindComputedProperty(get(parentPath, next));
+        const prop = get(parentPath, next);
+        if (prop) bindComputedProperty(prop);
       });
     }
     return next;


### PR DESCRIPTION
Fixes #400 
@ctrlplusb I was never able to truly track down why the next prop in get() would be missing the newly added model definition, but the reduce would return an undefined which would throw the error. Simply validating existence after the get() made the error go away and still performed the correct binding of the computed.

In the repo that has this issue, I am using a store provided through a package dependency and it does a number of addModel calls directly after one another, but I was never able to fully reproduce the issue consistently. 