### PR TITLE
Adds useLocalStore hook, deprecates createComponentStore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -799,6 +799,15 @@ export function createComponentStore<
   config?: StoreConfig,
 ): UseLocalStore<StoreModel, InitialData>;
 
+export function useLocalStore<
+  StoreModel extends object = {},
+  StoreConfig extends EasyPeasyConfig<any, any> = EasyPeasyConfig<any, any>
+>(
+  modelCreator: () => StoreModel,
+  dependencies?: any[],
+  storeConfig?: StoreConfig,
+): [State<StoreModel>, Actions<StoreModel>, Store<StoreModel, StoreConfig>];
+
 // #endregion
 
 // #region Persist

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "symbol-observable": "^1.2.0",
-    "ts-toolbelt": "^6.1.6"
+    "ts-toolbelt": "^6.1.6",
+    "use-memo-one": "^1.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/src/__tests__/typescript/use-local-store.tsx
+++ b/src/__tests__/typescript/use-local-store.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable */
+
+import * as React from 'react';
+import { useLocalStore, Action, action } from 'easy-peasy';
+
+interface StoreModel {
+  count: number;
+  inc: Action<StoreModel>;
+}
+
+const [state, actions, store] = useLocalStore<StoreModel>(() => ({
+  count: 0,
+  inc: action(state => {
+    state.count += 1;
+  }),
+}));
+
+state.count + 1;
+actions.inc();
+store.getState().count + 1;
+
+useLocalStore<StoreModel>(
+  () => ({
+    count: 0,
+    inc: action(state => {
+      state.count += 1;
+    }),
+  }),
+  ['foo', 123],
+);
+
+useLocalStore<StoreModel>(
+  () => ({
+    count: 0,
+    inc: action(state => {
+      state.count += 1;
+    }),
+  }),
+  ['foo', 123],
+  {
+    name: 'MyLocalStore',
+  },
+);

--- a/src/__tests__/use-local-store.test.js
+++ b/src/__tests__/use-local-store.test.js
@@ -159,3 +159,26 @@ test('with config', () => {
   // ASSERT
   expect(logs).toEqual(['@action.inc']);
 });
+
+test('returns the store', () => {
+  // ARRANGE
+  let actualStore;
+
+  // eslint-disable-next-line no-shadow
+  function CountDisplay() {
+    const [, , store] = useLocalStore(() => ({
+      count: 0,
+    }));
+    actualStore = store;
+    return null;
+  }
+
+  // ACT
+  const app = <CountDisplay count={1} />;
+
+  render(app);
+
+  // EXPECT
+  expect(actualStore).not.toBeUndefined();
+  expect(actualStore.getState()).toEqual({ count: 0 });
+});

--- a/src/__tests__/use-local-store.test.js
+++ b/src/__tests__/use-local-store.test.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { useLocalStore, action } from '../index';
+
+function CountDisplay() {
+  const [state, actions] = useLocalStore(() => ({
+    count: 0,
+    inc: action(s => {
+      s.count += 1;
+    }),
+  }));
+  return (
+    <>
+      <div data-testid="count">{state.count}</div>
+      <button data-testid="button" onClick={actions.inc} type="button">
+        +
+      </button>
+    </>
+  );
+}
+
+test('used in component', () => {
+  // arrange
+  const app = <CountDisplay />;
+
+  // act
+  const { getByTestId } = render(app);
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  // assert
+  expect(count.textContent).toBe('0');
+
+  // act
+  fireEvent.click(button);
+
+  // assert
+  expect(count.textContent).toBe('1');
+});
+
+test('multiple instances', async () => {
+  // arrange
+  const app = (
+    <>
+      <CountDisplay />
+      <CountDisplay />
+    </>
+  );
+
+  // act
+  const { findAllByTestId } = render(app);
+
+  const count = await findAllByTestId('count');
+  const button = await findAllByTestId('button');
+
+  // assert
+  expect(count[0].textContent).toBe('0');
+  expect(count[1].textContent).toBe('0');
+
+  // act
+  fireEvent.click(button[0]);
+
+  // assert
+  expect(count[0].textContent).toBe('1');
+  expect(count[1].textContent).toBe('0');
+
+  // act
+  fireEvent.click(button[1]);
+
+  // assert
+  expect(count[0].textContent).toBe('1');
+  expect(count[1].textContent).toBe('1');
+});
+
+test('with external data', () => {
+  // arrange
+
+  // eslint-disable-next-line no-shadow,react/prop-types
+  function CountDisplay({ count }) {
+    const [state, actions] = useLocalStore(
+      () => ({
+        count,
+        inc: action(_state => {
+          _state.count += 1;
+        }),
+      }),
+      [count],
+    );
+    return (
+      <>
+        <div data-testid="count">{state.count}</div>
+        <button data-testid="button" onClick={actions.inc} type="button">
+          +
+        </button>
+      </>
+    );
+  }
+
+  const app = <CountDisplay count={1} />;
+
+  // act
+  const { getByTestId } = render(app);
+
+  const count = getByTestId('count');
+  const button = getByTestId('button');
+
+  // assert
+  expect(count.textContent).toBe('1');
+
+  // act
+  fireEvent.click(button);
+
+  // assert
+  expect(count.textContent).toBe('2');
+});
+
+test('with config', () => {
+  // ACT
+  const logs = [];
+
+  const customMiddleware = () => next => _action => {
+    // assert
+    logs.push(_action.type);
+    next(_action);
+  };
+
+  // eslint-disable-next-line no-shadow,react/prop-types
+  function CountDisplay({ count }) {
+    const [state, actions] = useLocalStore(
+      () => ({
+        count,
+        inc: action(_state => {
+          _state.count += 1;
+        }),
+      }),
+      [count],
+      {
+        middleware: [customMiddleware],
+      },
+    );
+    return (
+      <>
+        <div data-testid="count">{state.count}</div>
+        <button data-testid="button" onClick={actions.inc} type="button">
+          +
+        </button>
+      </>
+    );
+  }
+
+  const app = <CountDisplay count={1} />;
+
+  const { getByTestId } = render(app);
+
+  const button = getByTestId('button');
+  fireEvent.click(button);
+
+  // ASSERT
+  expect(logs).toEqual(['@action.inc']);
+});

--- a/src/create-context-store.js
+++ b/src/create-context-store.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext } from 'react';
+import { useMemoOne } from 'use-memo-one';
 import {
   createStoreActionsHook,
   createStoreDispatchHook,
@@ -13,7 +14,7 @@ export default function createContextStore(model, config) {
   const StoreContext = createContext();
 
   function Provider({ children, initialData }) {
-    const store = useMemo(
+    const store = useMemoOne(
       () =>
         createStore(
           typeof model === 'function' ? model(initialData) : model,

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import createContextStore from './create-context-store';
 import createComponentStore from './create-component-store';
 import createTransform from './create-transform';
 import StoreProvider from './provider';
+import useLocalStore from './use-local-store';
 import {
   action,
   actionOn,
@@ -46,6 +47,7 @@ export {
   StoreProvider,
   thunk,
   thunkOn,
+  useLocalStore,
   useStoreActions,
   useStoreDispatch,
   useStoreState,

--- a/src/use-local-store.js
+++ b/src/use-local-store.js
@@ -1,0 +1,22 @@
+import { useEffect, useRef, useState } from 'react';
+import { useMemoOne } from 'use-memo-one';
+import createStore from './create-store';
+
+export default function useLocalStore(modelCreator, dependencies = [], config) {
+  const store = useMemoOne(
+    () => createStore(modelCreator(), config),
+    dependencies,
+  );
+  const previousStateRef = useRef(store.getState());
+  const [currentState, setCurrentState] = useState(() => store.getState());
+  useEffect(() => {
+    return store.subscribe(() => {
+      const nextState = store.getState();
+      if (previousStateRef.current !== nextState) {
+        previousStateRef.current = nextState;
+        setCurrentState(nextState);
+      }
+    });
+  }, [store]);
+  return [currentState, store.getActions()];
+}

--- a/src/use-local-store.js
+++ b/src/use-local-store.js
@@ -18,5 +18,5 @@ export default function useLocalStore(modelCreator, dependencies = [], config) {
       }
     });
   }, [store]);
-  return [currentState, store.getActions()];
+  return [currentState, store.getActions(), store];
 }

--- a/website/docs/.vuepress/config.js
+++ b/website/docs/.vuepress/config.js
@@ -85,6 +85,7 @@ module.exports = {
             {
               title: 'Hooks',
               children: [
+                'api/use-local-store',
                 'api/use-store-actions',
                 'api/use-store-dispatch',
                 'api/use-store-rehydrated',
@@ -97,6 +98,7 @@ module.exports = {
               children: [
                 'api/create-component-store',
                 'api/create-context-store',
+                'api/use-local-store',
               ],
             },
             {

--- a/website/docs/docs/api/create-component-store.md
+++ b/website/docs/docs/api/create-component-store.md
@@ -2,6 +2,8 @@
 
 > **DEPRECATED**
 >
+> This API will be removed in the next major release.
+>
 > Please use the [`useLocalStore`](/docs/api/use-local-store.html) hook instead.
 
 Allows you to create a store to represent the state for an individual React component. This is essentially an alternative to the official `useState` and `useReducer` hooks provided by React for component-level state.

--- a/website/docs/docs/api/create-component-store.md
+++ b/website/docs/docs/api/create-component-store.md
@@ -1,5 +1,9 @@
 # createComponentStore
 
+> **DEPRECATED**
+>
+> Please use the [`useLocalStore`](/docs/api/use-local-store.html) hook instead.
+
 Allows you to create a store to represent the state for an individual React component. This is essentially an alternative to the official `useState` and `useReducer` hooks provided by React for component-level state.
 
 ```javascript

--- a/website/docs/docs/api/use-local-store.md
+++ b/website/docs/docs/api/use-local-store.md
@@ -1,0 +1,132 @@
+# useLocalStore
+
+Allows you to create a store to represent the state for an individual React component. This is essentially an alternative to the official `useState` and `useReducer` hooks provided by React for component-level state.
+
+```javascript
+function MyCounter() {
+  const [state, actions] = useLocalStore(() => ({
+    count: 0,
+    increment: action(_state => {
+      _state.count += 1;
+    })
+  }));
+
+  return (
+    <div>
+      {state.count}
+      <button onClick={() => actions.increment()}>+</button>
+    </div>
+  );
+}
+```
+
+## Arguments
+
+  - `modelCreater` (() => Object, required)
+
+    A function that should return the model representing your store.
+
+    ```javascript
+    createComponentStore({
+      count: 0,
+      increment: action(state => {
+        state.count += 1;
+      })
+    });
+    ```
+
+  - `dependencies` (Array, optional, default=[])
+
+    A list of dependencies, similar to the official React hooks. If any of the values change then the store will be recreated. Especially helpful if your store depends on an external value, such as a prop.
+
+    By default an empty array will be used, meaning the store will not be recreated.
+
+  - `storeConfig` (Object, optional)
+
+    Provides custom configuration options for your store. Please see the [StoreConfig](/docs/api/store-config.html) API documentation for a full list of configuration options.
+
+    ```javascript
+    useLocalStore(() => model, [], { middleware: [loggerMiddleware] });
+    ```
+
+## Returns
+
+The hook returns a positional array;
+
+```typescript
+const [state, actions, store] = useLocalStore(/*...*/);
+```
+
+- `state`
+
+  The state of your store.
+
+- `actions`
+
+  The actions of your store.
+
+- `store`
+
+  The actual store instance - for advanced cases.
+
+## Example
+
+This example shows how you can use the hook within your component.
+
+```javascript
+import { useLocalStore } from 'easy-peasy';
+
+function MyCounter() {
+  const [state, actions] = useLocalStore(() => ({
+    count: 0,
+    inc: action(_state => {
+      _state.count += 1;
+    })
+  }));
+  return (
+    <>
+      <div>{state.count}</div>
+      <button onClick={() => actions.inc()} type="button"> + </button>
+    </>
+  );
+}
+```
+
+## Reinitialising your model based on incoming props
+
+There may be cases in which you may want to reinitialize your store based on some incoming props. The store hook will only initialize once for each use. To get around this simply define the dependency array, providing a list of props, that when they change will cause the store to be recreated.
+
+```javascript
+import { useLocalStore, action } from 'easy-peasy';
+
+const useCounter = createComponentStore({
+  count: 0,
+  inc: action(state => {
+    state.count += 1;
+  }),
+});
+
+function EditProduct({ id, name }) {
+  const [state, actions] = useLocalStore(
+    () => ({
+      id,
+      name,
+      setName: action((_state, payload) => {
+        _state.name = payload;
+      })
+    }),
+    [id, name] // 👈 if any of these change the store is recreated
+  );
+
+  return (
+    <>
+      <div>Product {state.id}</div>
+      <input
+        onChange={e => actions.setName(e.target.value)}
+        type="text"
+        value={state.name}
+      />
+    </>
+  );
+}
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -6391,6 +6391,11 @@ urlgrey@0.4.4:
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
This PR deprecates `createComponentStore`. The API for `createComponentStore` was a bit verbose and limited. It will be removed in the next major release.

I plan to release non breaking changes for a while still, so no stress.

# useLocalStore

Allows you to create a store to represent the state for an individual React component. This is essentially an alternative to the official `useState` and `useReducer` hooks provided by React for component-level state.

```javascript
function MyCounter() {
  const [state, actions] = useLocalStore(() => ({
    count: 0,
    increment: action(_state => {
      _state.count += 1;
    })
  }));

  return (
    <div>
      {state.count}
      <button onClick={() => actions.increment()}>+</button>
    </div>
  );
}
```

## Arguments

  - `modelCreater` (() => Object, required)

    A function that should return the model representing your store.

    ```javascript
    createComponentStore({
      count: 0,
      increment: action(state => {
        state.count += 1;
      })
    });
    ```

  - `dependencies` (Array, optional, default=[])

    A list of dependencies, similar to the official React hooks. If any of the values change then the store will be recreated. Especially helpful if your store depends on an external value, such as a prop.

    By default an empty array will be used, meaning the store will not be recreated.

  - `storeConfig` (Object, optional)

    Provides custom configuration options for your store. Please see the [StoreConfig](/docs/api/store-config.html) API documentation for a full list of configuration options.

    ```javascript
    useLocalStore(() => model, [], { middleware: [loggerMiddleware] });
    ```

## Returns

The hook returns a positional array;

```typescript
const [state, actions, store] = useLocalStore(/*...*/);
```

- `state`

  The state of your store.

- `actions`

  The actions of your store.

- `store`

  The actual store instance - for advanced cases.

## Example

This example shows how you can use the hook within your component.

```javascript
import { useLocalStore } from 'easy-peasy';

function MyCounter() {
  const [state, actions] = useLocalStore(() => ({
    count: 0,
    inc: action(_state => {
      _state.count += 1;
    })
  }));
  return (
    <>
      <div>{state.count}</div>
      <button onClick={() => actions.inc()} type="button"> + </button>
    </>
  );
}
```

## Reinitialising your model based on incoming props

There may be cases in which you may want to reinitialize your store based on some incoming props. The store hook will only initialize once for each use. To get around this simply define the dependency array, providing a list of props, that when they change will cause the store to be recreated.

```javascript
import { useLocalStore, action } from 'easy-peasy';

function EditProduct({ id, name }) {
  const [state, actions] = useLocalStore(
    () => ({
      id,
      name,
      setName: action((_state, payload) => {
        _state.name = payload;
      })
    }),
    [id, name] // 👈 if any of these change the store is recreated
  );

  return (
    <>
      <div>Product {state.id}</div>
      <input
        onChange={e => actions.setName(e.target.value)}
        type="text"
        value={state.name}
      />
    </>
  );
}
```
