### PR TITLE
refactor(recipesDoc): renamed selector to computed

### DIFF
--- a/website/docs/docs/recipes/generalising-models.md
+++ b/website/docs/docs/recipes/generalising-models.md
@@ -8,7 +8,7 @@ For example, say you had the following:
 const store = createStore({
   products: {
     data: {},
-    ids: selector(
+    ids: computed(
       [state => state.data],
       (resolvedState) => {
         const [data] = resolvedState;
@@ -27,7 +27,7 @@ const store = createStore({
   },
   users: {
     data: {},
-    ids: selector(
+    ids: computed(
       [state => state.data],
       (resolvedState) => {
         const [data] = resolvedState;
@@ -52,7 +52,7 @@ You will note a distinct pattern between the `products` and `users`. You could c
 ```javascript
 const dataModel = (endpoint) => ({
   data: {},
-  ids: selector(
+  ids: computed(
     [state => state.data],
     (resolvedState) => {
       const [data] = resolvedState;


### PR DESCRIPTION
I believe the name changed a while ago, but wasn't reflected in this doc.