### PR TITLE
(typescript) fix state use Map or Set value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,7 +196,7 @@ type StateMapper<StateModel extends object, Depth extends string> = {
     : StateModel[P] extends Reducer<any, any>
     ? StateModel[P]['result']
     : StateModel[P] extends object
-    ? StateModel[P] extends string | Array<any> | RegExp | Date | Function
+    ? StateModel[P] extends string | Array<any> | RegExp | Date | Function | Map | Set | WeakMap | WeakSet
       ? StateModel[P]
       : RecursiveState<
           StateModel[P],


### PR DESCRIPTION
when declare a state as `Map` (or `Set`, `WeakMap`, `WeakSet`), with `computed` (or `action`, `thunk`), the state will be resolve as a `StateMapper` type (it should be original `Map`)

```ts
interface NameSpaceCollectionStoreModel {
  accounts: Map<string, Account>;
};

const collection: NameSpaceCollectionStoreModel = {
entries: computed(state => {
    const accounts = state.accounts;
  })
};
```

![1589286451841](https://user-images.githubusercontent.com/2003859/81691219-0e566a80-948f-11ea-982b-81364f2954d5.jpg)