### PR TITLE
Fix persist transformers order

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 <p align='center'>Vegetarian friendly state for React</p>
 <p>&nbsp;</p>
 
+
+Easy Peasy provides you with an intuitive API to quickly and easily manage the state for your React application. Batteries are included - no configuration is required to support derived state, API calls, performance optimisation, developer tools etc.
+
 [![npm](https://img.shields.io/npm/v/easy-peasy.svg?style=flat-square)](http://npm.im/easy-peasy)
 [![MIT License](https://img.shields.io/npm/l/easy-peasy.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![Travis](https://img.shields.io/travis/ctrlplusb/easy-peasy.svg?style=flat-square)](https://travis-ci.org/ctrlplusb/easy-peasy)
@@ -70,10 +73,6 @@ function TodoList() {
   - React Native supported
   - Redux Dev Tools supported
   - Hot Reloading supported
-
-## Introduction
-
-Easy Peasy provides you with an intuitive API to quickly and easily manage the state for your React application. Batteries are included - no configuration is required to support derived state, API calls, performance optimisation, developer tools etc.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align='center'>
   <img src="https://i.imgur.com/UnPLVly.png" width="280" />
 </p>
-<p align='center'>Vegetarian friendly state for React</p>
+<p align='center'><strong>Vegetarian friendly state for React</strong></p>
 <p>&nbsp;</p>
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Vegetarian friendly state for React",
   "license": "MIT",
   "main": "dist/easy-peasy.cjs.js",

--- a/src/__tests__/persist.test.js
+++ b/src/__tests__/persist.test.js
@@ -428,6 +428,69 @@ test('transformers', () => {
   });
 });
 
+test('transformers order', () => {
+  // ARRANGE
+  const setTransformer = createTransform(
+    data => {
+      return [...data];
+    },
+    data => {
+      return new Set(data);
+    },
+  );
+
+  const jsonTransformer = createTransform(
+    data => {
+      return JSON.stringify(data);
+    },
+    data => {
+      return JSON.parse(data);
+    },
+  );
+
+  const memoryStorage = createMemoryStorage();
+
+  const makeStore = () =>
+    createStore(
+      persist(
+        {
+          one: null,
+          two: null,
+          change: action((_, payload) => {
+            return payload;
+          }),
+        },
+        {
+          storage: memoryStorage,
+          transformers: [setTransformer, jsonTransformer],
+        },
+      ),
+    );
+
+  const store = makeStore();
+
+  // ACT
+  store.getActions().change({
+    one: new Set([1, 2]),
+    two: new Set([3, 4]),
+  });
+
+  // ASSERT
+  expect(memoryStorage.store).toEqual({
+    '[EasyPeasyStore]@one': '[1,2]',
+    '[EasyPeasyStore]@two': '[3,4]',
+  });
+
+  // ACT
+  const rehydratedStore = makeStore();
+
+  // ASSERT
+  expect(rehydratedStore.getState()).toEqual({
+    one: new Set([1, 2]),
+    two: new Set([3, 4]),
+  });
+});
+
 test('multiple stores', () => {
   // ARRANGE
   const memoryStorage = createMemoryStorage();

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -41,7 +41,7 @@ function createStorageWrapper(storage = sessionStorage, transformers = []) {
     }
   }
 
-  const outTransformers = transformers.reverse();
+  const outTransformers = [...transformers].reverse();
 
   const serialize = (data, key) => {
     const simpleKey = key.substr(key.indexOf('@') + 1);


### PR DESCRIPTION
Hi. While trying to make multiple transformers work (and almost losing my sanity) I encounter a bug with transformers order. Its caused by using transformers.reverse() method that mutates the array.

Expected result: transformers are applied **left to right** on persisting and **right to left** on rehydrating.

Actual result: transformers are applied **right to left** on persisting and **right to left** on rehydrating.

This fixes the issue and works according to https://easy-peasy.now.sh/docs/api/persist.html