### PR TITLE
[docs] Fix broken link to create-typed-hooks file

### DIFF
--- a/website/docs/docs/typescript-tutorial/typed-hooks.md
+++ b/website/docs/docs/typescript-tutorial/typed-hooks.md
@@ -12,9 +12,9 @@ function MyComponent() {
 }
 ```
 
-That is slightly cumbersome, therefore for convenience sake, we expose a [createTypedHooks](/docs/api/create-typed-hooks.html) API which allows you to create versions of the hooks which are pre-bound within your StoreModel. Using the hooks returned by this API allows you to avoid having to provide your StoreModel every time you use one of the hooks.
+That is slightly cumbersome, therefore for convenience sake, we expose a [createTypedHooks](/docs/typescript-api/create-typed-hooks.html) API which allows you to create versions of the hooks which are pre-bound within your StoreModel. Using the hooks returned by this API allows you to avoid having to provide your StoreModel every time you use one of the hooks.
 
-We therefore recommend that you use the [createTypedHooks](/docs/api/create-typed-hooks.html) API to create typed hooks and then export them so that you can use them within your components.
+We therefore recommend that you use the [createTypedHooks](/docs/typescript-api/create-typed-hooks.html) API to create typed hooks and then export them so that you can use them within your components.
 
 ## Exporting the typed hooks
 


### PR DESCRIPTION
On the [Typescript Tutorial](https://easy-peasy.now.sh/docs/typescript-tutorial/typed-hooks.html), there is a link to the [createTypedHooks](https://easy-peasy.now.sh/docs/api/create-typed-hooks.html) page.

The docs have moved. The page is now [under the `typescript-api` directory](https://easy-peasy.now.sh/docs/typescript-api/create-typed-hooks.html).

![easy-peasy-404-link](https://user-images.githubusercontent.com/35032643/87644802-490da500-c755-11ea-8a27-c71d76bfd48a.gif)

