### PR TITLE
Use `StoreModel` as the default type argument for createContextStore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1034,7 +1034,7 @@ interface StoreModelInitializer<
 
 export function createContextStore<
   StoreModel extends object = {},
-  InitialData extends undefined | object = StoreModel,
+  InitialData extends undefined | object = State<StoreModel>,
   StoreConfig extends EasyPeasyConfig<any, any> = EasyPeasyConfig<{}, any>
 >(
   model: StoreModel | StoreModelInitializer<StoreModel, InitialData>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1034,7 +1034,7 @@ interface StoreModelInitializer<
 
 export function createContextStore<
   StoreModel extends object = {},
-  InitialData extends undefined | object = undefined,
+  InitialData extends undefined | object = StoreModel,
   StoreConfig extends EasyPeasyConfig<any, any> = EasyPeasyConfig<{}, any>
 >(
   model: StoreModel | StoreModelInitializer<StoreModel, InitialData>,


### PR DESCRIPTION
Use `StoreModel` as the default type argument for createContextStore's `InitialData` type

#526