### PR TITLE
Added missing possible word

### DIFF
--- a/website/docs/docs/testing/testing-components.md
+++ b/website/docs/docs/testing/testing-components.md
@@ -65,7 +65,7 @@ This grants us great power in being able to test our components with a great deg
 
 ## Utilising initialState to predefine state
 
-It is also to preload your store with some state by utilising the `initialState` configuration property of the store. This may help you test specific conditions of your component.
+It is also possible to preload your store with some state by utilising the `initialState` configuration property of the store. This may help you test specific conditions of your component.
   
 ```javascript
 test('Counter', () => {


### PR DESCRIPTION
Added missing possible word from the following sentence: 

"It is also to preload your store with some state by utilising the `initialState` configuration property of the store."