### PR TITLE
Document fail api use

### DIFF
--- a/website/docs/docs/api/computed.md
+++ b/website/docs/docs/api/computed.md
@@ -14,7 +14,7 @@ isLoggedIn: computed(state => state.user != null)
 
   > Note: this is an optional parameter, you can omit it and instead just provide a `computationFunc`.
 
-  State resolvers allows you to isolate the specific parts of your state as inputs to your computation function. They also have the added benefit of being able to expose the entire store state to your computed property. Each state resolver function receives the following arguments:
+  State resolvers allow you to isolate the specific parts of your state as inputs to your computation function. They also have the added benefit of being able to expose the entire store state to your computed property. Each state resolver function receives the following arguments:
 
   - `state` (Object)
 

--- a/website/docs/docs/api/thunk.md
+++ b/website/docs/docs/api/thunk.md
@@ -37,6 +37,10 @@ thunk(async (actions, payload) => {
       - `dispatch` (Function)
 
         The Redux dispatch function, allowing you to dispatch "standard" Redux actions.
+        
+      - `fail` (Function)
+      
+        The Fail API function, allowing you to explicitly signal thunk failure, see [Debugging Thunks](/docs/api/thunk.html#debugging-thunks). You may pass your error object or any arbitrary payload to fail.  
 
       - `getState` (Function)
 
@@ -139,6 +143,8 @@ Dispatching these actions results in the following benefits:
 2. Enables listeners to be attached to specific [thunk](/docs/api/thunk.html) states (i.e. *started*, *completed*, or *failed*)
 
 Using the [Redux Dev Tools](https://github.com/zalmoxisus/redux-devtools-extension) extension you will be able see your dispatched [thunks](/docs/api/thunk.html) as they flow through each of their states. You will also see the payload that was provided to the [thunk](/docs/api/thunk.html).
+
+> Note: The `start` and `success` actions will dispatch automatically. To trigger the `fail` action, call `helpers.fail(error)` within your thunk. In addition to the thunk's payload, this action will receive the argument you pass to `fail()`, which can be any arbitrary data useful in to your debugging.
 
 <img src="../../assets/devtools-thunk.png" />
 

--- a/website/docs/docs/api/thunk.md
+++ b/website/docs/docs/api/thunk.md
@@ -144,7 +144,7 @@ Dispatching these actions results in the following benefits:
 
 Using the [Redux Dev Tools](https://github.com/zalmoxisus/redux-devtools-extension) extension you will be able see your dispatched [thunks](/docs/api/thunk.html) as they flow through each of their states. You will also see the payload that was provided to the [thunk](/docs/api/thunk.html).
 
-> Note: The `start` and `success` actions will dispatch automatically. To trigger the `fail` action, call `helpers.fail(error)` within your thunk. In addition to the thunk's payload, this action will receive the argument you pass to `fail()`, which can be any arbitrary data useful in to your debugging.
+> Note: The `start` and `success` actions will dispatch automatically. To trigger the `fail` action, call `helpers.fail(error)` within your thunk. In addition to the thunk's payload, this action will receive the argument you pass to `fail()`, which can be any arbitrary data useful for your debugging.
 
 <img src="../../assets/devtools-thunk.png" />
 


### PR DESCRIPTION
This PR updates the `/docs/api/thunk` page to add the existence of the v4 `helpers.fail` function and document how to use it in thunk debugging. 

I had to code-dive to find out how to trigger failure status and was very happy to find an explicit function for this. It really let me use the thunk the way I wanted to, however, it would be fantastic to have it in the docs. 

I hope this helps! 