### PR TITLE
Adds direct polyfill support & updates docs

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "index.js": {
-    "bundled": 46746,
-    "minified": 20221,
-    "gzipped": 6426,
+    "bundled": 56081,
+    "minified": 23293,
+    "gzipped": 6973,
     "treeshaked": {
       "rollup": {
-        "code": 209,
-        "import_statements": 168
+        "code": 139,
+        "import_statements": 135
       },
       "webpack": {
-        "code": 2607
+        "code": 2578
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 58965,
-    "minified": 25523,
-    "gzipped": 7235
+    "bundled": 57629,
+    "minified": 24610,
+    "gzipped": 7162
   },
   "index.iife.js": {
-    "bundled": 61798,
-    "minified": 20702,
-    "gzipped": 6593
+    "bundled": 60584,
+    "minified": 20129,
+    "gzipped": 6533
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1117,3 +1117,11 @@ export function persist<Model extends object = {}>(
 export function useStoreRehydrated(): boolean;
 
 // #endregion
+
+
+// #region Polyfills
+
+export function enableES5(): void;
+export function enableMapSet(): void;
+
+// #endregion

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export * from './create-transform';
 export * from './provider';
 export * from './use-local-store';
 export * from './helpers';
+export * from './polyfills';

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,1 @@
+export { enableES5, enableMapSet } from 'immer';

--- a/website/docs/docs/introduction/browser-support.md
+++ b/website/docs/docs/introduction/browser-support.md
@@ -36,24 +36,20 @@ addTodo: action((state, payload) => {
 
 That's just a simple example. More complex/nested updates can get very tricky to manage.
 
-## Configuring Immer to support ES5
+## Supporting older browsers (IE11)
 
-When Immer released version 7 of the library they tried to tackle the growing package size. In order to do so they split out "additional" features into separate imports. For example support for ES5, or for Map/Set support.
-
-We have decided to not include these features by default, so if you are in need of supporting older browsers or React Native environments then you need to explicity import the `enableES5` helper from Immer.
+To support older browsers, you need to import and "activate" polyfills at the start of your app:
 
 ```javascript
-import { enableES5 } from 'immer';
+import { enableES5, enableMapSet } 'easy-peasy';
 
+/**
+ * Requried for Immer to work properly in older browsers.
+ */
 enableES5();
-```
 
-In addition to this, if you would like to support mutating of Map/Set based state then you can run the required helper like so.
-
-```javascript
-import { enableMapSet } from 'immer';
-
+/**
+ * Include this if you are mutating Map/Set
+ */
 enableMapSet();
 ```
-
-It is best to do this at the start of your application.


### PR DESCRIPTION
Exposing the polyfill methods directly from easy-peasy,
enables users of this library to omit the "immer" dependency.

- Adds `polyfill.js`, which exports Immer polyfill methods.
- Rewrites section for `browser-support.md`.