### PR TITLE
Minor name fix in Thunk docs

### DIFF
--- a/website/docs/docs/api/thunk.md
+++ b/website/docs/docs/api/thunk.md
@@ -88,7 +88,7 @@ To enable a [thunk](/docs/api/thunk.html) to be asynchronous simply use `async/a
 ```javascript
 const todosModel = {
   todos: [],
-  savedTodo: action((state, payload) => {
+  addTodo: action((state, payload) => {
     state.todos.push(payload);
   }),
   //     👇 our asynchronous thunk makes use of async/await


### PR DESCRIPTION
I think it was meant to be `addTodo` =)

![image](https://user-images.githubusercontent.com/26604994/110258734-1c233200-7f72-11eb-90d9-9a943a34ebae.png)
