### PR TITLE
Remove fast-memoize from docs

### DIFF
--- a/website/docs/docs/api/computed.md
+++ b/website/docs/docs/api/computed.md
@@ -158,12 +158,10 @@ function Todo({ id }) {
 Note that only the function that you return will be memoized. If you wish to
 memoize the results from the function itself you will need to utilize a
 memoization utility, such as
-[`memoizerific`](https://github.com/caiogondim/fast-memoize.js).
+[`memoizerific`](https://github.com/thinkloop/memoizerific).
 
 ```javascript
 import memoize from 'memoizerific';
-
-const memoizedFind = memoize((state, id) => state.items.find((todo) => todo.id === id), 1)
 
 const todos = {
   items: [{ id: 1, text: 'answer questions' }],
@@ -171,7 +169,7 @@ const todos = {
   todoById: computed((state) => {
     // Wrap the returned function with the memoize utility
     //        👇
-    return (id) => memoizedFind(state, id);
+    return memoize((id) => state.items.find((todo) => todo.id === id), 1);
   }),
 };
 ```

--- a/website/docs/docs/api/computed.md
+++ b/website/docs/docs/api/computed.md
@@ -158,10 +158,12 @@ function Todo({ id }) {
 Note that only the function that you return will be memoized. If you wish to
 memoize the results from the function itself you will need to utilize a
 memoization utility, such as
-[`fast-memoize`](https://github.com/caiogondim/fast-memoize.js).
+[`memoizerific`](https://github.com/caiogondim/fast-memoize.js).
 
 ```javascript
-import memoize from 'fast-memoize';
+import memoize from 'memoizerific';
+
+const memoizedFind = memoize((state, id) => state.items.find((todo) => todo.id === id), 1)
 
 const todos = {
   items: [{ id: 1, text: 'answer questions' }],
@@ -169,7 +171,7 @@ const todos = {
   todoById: computed((state) => {
     // Wrap the returned function with the memoize utility
     //        👇
-    return memoize((id) => state.items.find((todo) => todo.id === id));
+    return (id) => memoizedFind(state, id);
   }),
 };
 ```


### PR DESCRIPTION
I would strongly recommend against using fast-memoize in these docs. It will jsonify the incoming argument parameters. The user is likely to be memoizing against large state objects. The cost of stringifying these large objects could easily outweigh the performance benefits of memoization. 

`fast-memoize` is well benchmarked for use cases when you are memoizing a function which takes small integers as arguments. `fast-memoize` benchmarking also does not incorporate key deletion or any polymorphic pressure exerted on the engine.  For easy peasy, most of the time in my experience, you are memoizing large objects as keys in the memoized cache. Memoizerific and other memoization libraries are able to cache objects effectively because the javascript engine stores a random ID on every object and ES6 `Map` is able to use that ID. Therefore object lookup in a `Map` will amount to an integer comparison whereas with `fast-memoize` this comparison will amount to serializing the entire object and then comparing long strings.