### PR TITLE
Allow lodash-style string notation to select state and actions

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "index.js": {
-    "bundled": 51094,
-    "minified": 21607,
-    "gzipped": 6493,
+    "bundled": 51422,
+    "minified": 21626,
+    "gzipped": 6495,
     "treeshaked": {
       "rollup": {
-        "code": 135,
-        "import_statements": 131
+        "code": 154,
+        "import_statements": 150
       },
       "webpack": {
-        "code": 2574
+        "code": 2773
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 52470,
-    "minified": 22792,
-    "gzipped": 6663
+    "bundled": 52899,
+    "minified": 22881,
+    "gzipped": 6673
   },
   "index.iife.js": {
-    "bundled": 55375,
-    "minified": 18500,
-    "gzipped": 6060
+    "bundled": 55805,
+    "minified": 18547,
+    "gzipped": 6064
   },
   "ie11.js": {
     "bundled": 102,

--- a/index.d.ts
+++ b/index.d.ts
@@ -953,7 +953,7 @@ export function useStoreState<
   StoreState extends State<any> = State<{}>,
   Result = any
 >(
-  mapState: (state: StoreState) => Result,
+  mapState: (state: StoreState) => Result | string,
   equalityFn?: (prev: Result, next: Result) => boolean,
 ): Result;
 
@@ -976,7 +976,7 @@ export function useStoreState<
 export function useStoreActions<
   StoreActions extends Actions<any> = Actions<{}>,
   Result = any
->(mapActions: (actions: StoreActions) => Result): Result;
+>(mapActions: (actions: StoreActions) => Result | string): Result;
 
 /**
  * A react hook that returns the store instance.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.8",
     "immer": "^8.0.1",
+    "lodash.get": "^4.4.2",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "ts-toolbelt": "^9.3.12"

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,3 +1,4 @@
+import get from 'lodash.get';
 import {
   useContext,
   useEffect,
@@ -22,6 +23,12 @@ const useIsomorphicLayoutEffect =
 export function createStoreStateHook(Context) {
   return function useStoreState(mapState, equalityFn) {
     const store = useContext(Context);
+
+    if (typeof mapState === 'string') {
+      const path = mapState;
+      mapState = (state) => get(state, path);
+    }
+
     const mapStateRef = useRef(mapState);
     const stateRef = useRef();
     const mountedRef = useRef(true);
@@ -96,6 +103,12 @@ export const useStoreState = createStoreStateHook(EasyPeasyContext);
 export function createStoreActionsHook(Context) {
   return function useStoreActions(mapActions) {
     const store = useContext(Context);
+
+    if (typeof mapActions === 'string') {
+      const path = mapActions;
+      mapActions = (state) => get(state, path);
+    }
+
     return mapActions(store.getActions());
   };
 }

--- a/tests/use-store-state.test.js
+++ b/tests/use-store-state.test.js
@@ -348,3 +348,65 @@ test('equality function', () => {
   expect(renderSpy).toHaveBeenCalledTimes(2);
   expect(getByTestId('name').textContent).toBe('joel');
 });
+
+test('accessing state using lodash-style path notation', () => {
+  const randomName = Math.random().toString();
+  const store = createStore({
+    user: {
+      name: randomName,
+    },
+  });
+
+  function App() {
+    const name = useStoreState('user.name');
+    return (
+      <>
+        <span data-testid="name">{name}</span>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(getByTestId('name').textContent).toBe(randomName);
+});
+
+test('accessing actions using lodash-style path notation', () => {
+  const randomName = Math.random().toString();
+  const randomName2 = Math.random().toString();
+  const store = createStore({
+    user: {
+      name: randomName,
+      change: action((state, payload) => {
+        state.name = payload;
+      }),
+    },
+  });
+
+  function App() {
+    const name = useStoreState('user.name');
+    const change = useStoreActions('user.change');
+    return (
+      <>
+        <span data-testid="name">{name}</span>
+        <button data-testid="change" onClick={() => change(randomName2)}>
+          Change
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  fireEvent.click(getByTestId('change'));
+
+  expect(getByTestId('name').textContent).toBe(randomName2);
+});

--- a/website/docs/docs/api/use-store-actions.md
+++ b/website/docs/docs/api/use-store-actions.md
@@ -8,13 +8,15 @@ const addTodo = useStoreActions(actions => actions.todos.add);
 
 ## Arguments
 
-  - `mapActions` (Function, required)
+  - `mapActions` (Function or String, required)
 
     The function that is used to resolve the [action](/docs/api/action.html) that your component requires. It receives the following arguments:
 
     - `actions` (Object)
 
       The [actions](/docs/api/action.html) of your store.
+
+    Or a [lodash-style path notation](https://lodash.com/docs/4.17.15#get).
 
 ## Example
 
@@ -25,6 +27,22 @@ import { useStoreActions } from 'easy-peasy';
 const AddTodo = () => {
   const [text, setText] = useState('');
   const addTodo = useStoreActions(actions => actions.todos.add);
+  return (
+    <div>
+      <input value={text} onChange={(e) => setText(e.target.value)} />
+      <button onClick={() => addTodo(text)}>Add</button>
+    </div>
+  );
+};
+```
+
+```javascript
+import { useState } from 'react';
+import { useStoreActions } from 'easy-peasy';
+
+const AddTodo = () => {
+  const [text, setText] = useState('');
+  const addTodo = useStoreActions('todos.add');
   return (
     <div>
       <input value={text} onChange={(e) => setText(e.target.value)} />

--- a/website/docs/docs/api/use-store-state.md
+++ b/website/docs/docs/api/use-store-state.md
@@ -8,13 +8,15 @@ const todos = useStoreState(state => state.todos.items);
 
 ## Arguments
 
-  - `mapState` (Function, *required*)
+  - `mapState` (Function or String, *required*)
 
     The function that is used to resolve the piece of state that your component requires. The function will receive the following arguments:
 
     - `state` (Object)
 
       The state of your store.
+
+    Or a [lodash-style path notation](https://lodash.com/docs/4.17.15#get).
 
   - `equalityFn` (Function, *optional*)
 
@@ -48,6 +50,21 @@ import { useStoreState } from 'easy-peasy';
 const BasketTotal = () => {
   const totalPrice = useStoreState(state => state.basket.totalPrice);
   const netPrice = useStoreState(state => state.basket.netPrice);
+  return (
+    <div>
+      <div>Total: {totalPrice}</div>
+      <div>Net: {netPrice}</div>
+    </div>
+  );
+};
+```
+
+```javascript
+import { useStoreState } from 'easy-peasy';
+
+const BasketTotal = () => {
+  const totalPrice = useStoreState('basket.totalPrice);
+  const netPrice = useStoreState('basket.netPrice');
   return (
     <div>
       <div>Total: {totalPrice}</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5702,6 +5702,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"


### PR DESCRIPTION
This PR aims to allow the use of [lodash-style `get` path notation](https://lodash.com/docs/4.17.15#get) to access state and actions.
e.g.

```javascript
const store = createStore({
  user: {
    name: 'John',
   change: action((state, payload) => { state.name = payload; })
  }
});
```

Earlier

```javascript
function App() {
  const name = useStoreState(state => state.user.name);
  const change = useStoreActions(state => state.user.change);
}
```

Now

```javascript
function App() {
  const name = useStoreState('user.name');
  const change = useStoreActions('user.change');
}
```

This is meant for just convenience and nothing else.