### PR TITLE
Replace link on line 10

### DIFF
--- a/website/docs/docs/api/persist.md
+++ b/website/docs/docs/api/persist.md
@@ -7,7 +7,7 @@ tab, etc).
 By default it uses the browser's
 [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage),
 however, you can configure it to use
-[`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage),
+[`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage),
 or provide a custom storage engine.
 
 - [API](#api)


### PR DESCRIPTION
The link for the word "localStorage" used to lead to mdn page on Session storage instead of the mdn page on local storage. Replaced the link