### PR TITLE
React 18 requirement in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1065,6 +1065,7 @@ export function createTypedHooks<StoreModel extends object = {}>(): {
  */
 export class StoreProvider<StoreModel extends object = {}> extends Component<{
   store: Store<StoreModel>;
+  children?: React.ReactNode;
 }> {}
 
 // #endregion


### PR DESCRIPTION
With this little patch I was able to upgrade React to 18 without any additional changes in code using `easy-peasy`. It might NOT fix https://github.com/ctrlplusb/easy-peasy/issues/741 nor https://github.com/ctrlplusb/easy-peasy/issues/740 , but it worked for me :sweat_smile: 