### PR TITLE
chore: Fixes some tests to work cross platform

### DIFF
--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -1114,7 +1114,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 1,
   });
 
-  await wait(20);
+  await wait(17);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1122,7 +1122,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 2,
   });
 
-  await wait(20);
+  await wait(17);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1130,7 +1130,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 3,
   });
 
-  await wait(20);
+  await wait(17);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1138,7 +1138,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 4,
   });
 
-  await wait(20);
+  await wait(16);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1146,7 +1146,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 5,
   });
 
-  await wait(20);
+  await wait(17);
 
   // Now we have waited 100ms, so the storage should have persisted the first
   // change by now
@@ -1154,11 +1154,11 @@ test("multiple changes don't cause concurrent persist operations", async () => {
 
   // It would then fire the last change (i.e. the counter=5 change), which
   // would take 80ms to persist in the configured storage engine
-  await wait(20);
+  await wait(17);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
-  await wait(20);
+  await wait(17);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
-  await wait(20);
+  await wait(16);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
   await wait(40);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(5);

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -1114,7 +1114,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 1,
   });
 
-  await wait(17);
+  await wait(20);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1122,7 +1122,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 2,
   });
 
-  await wait(17);
+  await wait(20);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1130,7 +1130,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 3,
   });
 
-  await wait(17);
+  await wait(20);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1138,7 +1138,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 4,
   });
 
-  await wait(16);
+  await wait(20);
 
   expect(memoryStorage.store['[EasyPeasyStore][0]']).toBeUndefined();
 
@@ -1146,7 +1146,7 @@ test("multiple changes don't cause concurrent persist operations", async () => {
     counter: 5,
   });
 
-  await wait(17);
+  await wait(20);
 
   // Now we have waited 100ms, so the storage should have persisted the first
   // change by now
@@ -1154,11 +1154,11 @@ test("multiple changes don't cause concurrent persist operations", async () => {
 
   // It would then fire the last change (i.e. the counter=5 change), which
   // would take 80ms to persist in the configured storage engine
-  await wait(17);
+  await wait(20);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
-  await wait(17);
+  await wait(20);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
-  await wait(16);
+  await wait(20);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(1);
   await wait(40);
   expect(memoryStorage.store['[EasyPeasyStore][0]'].counter).toBe(5);

--- a/tests/use-store-state.test.js
+++ b/tests/use-store-state.test.js
@@ -144,8 +144,10 @@ test('throws an error if state mapping fails', () => {
   });
 
   // ASSERT
+  // expect either "Cannot read property 'text' of undefined" or "Cannot read properties of undefined (reading 'text')"
+  expect(getByTestId('error').textContent).toMatch("'text'");
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read property 'text' of undefined",
+    /Cannot read [property|properties](.+)of undefined/i,
   );
 });
 
@@ -177,8 +179,10 @@ test('throws an error for an invalid subscription only update', () => {
   });
 
   // ASSERT
+  // expect either "Cannot read property 'text' of undefined" or "Cannot read properties of undefined (reading 'text')"
+  expect(getByTestId('error').textContent).toMatch("'text'");
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read property 'text' of undefined",
+    /Cannot read [property|properties](.+)of undefined/i,
   );
 });
 


### PR DESCRIPTION
On windows using `node@16.15.0`, 3 tests are failing.

Adjusts tests slightly to make them pass in this environment.