### PR TITLE
Module not found use-sync-external-store/shim and two failing tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 // older versions of React (16/17), so we are utilsing a shim provided by the
 // React team which will ensure backwards compatibility;
 // eslint-disable-next-line import/no-unresolved
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 
 import { initializeUseStoreState } from './hooks';
 

--- a/tests/use-store-state.test.js
+++ b/tests/use-store-state.test.js
@@ -145,7 +145,7 @@ test('throws an error if state mapping fails', () => {
 
   // ASSERT
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read property 'text' of undefined",
+    "Cannot read properties of undefined (reading 'text')",
   );
 });
 
@@ -178,7 +178,7 @@ test('throws an error for an invalid subscription only update', () => {
 
   // ASSERT
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read property 'text' of undefined",
+    "Cannot read properties of undefined (reading 'text')",
   );
 });
 

--- a/tests/use-store-state.test.js
+++ b/tests/use-store-state.test.js
@@ -145,7 +145,7 @@ test('throws an error if state mapping fails', () => {
 
   // ASSERT
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read properties of undefined (reading 'text')",
+    "Cannot read property 'text' of undefined",
   );
 });
 
@@ -178,7 +178,7 @@ test('throws an error for an invalid subscription only update', () => {
 
   // ASSERT
   expect(getByTestId('error').textContent).toMatch(
-    "Cannot read properties of undefined (reading 'text')",
+    "Cannot read property 'text' of undefined",
   );
 });
 


### PR DESCRIPTION
fixed Module not found: Can't resolve 'use-sync-external-store/shim/with-selector' by changing the import according to https://github.com/reactwg/react-18/discussions/86