### PR TITLE
chore: Adds dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    target-branch: 'master'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'


### PR DESCRIPTION
It seems there is no way to make dependabot ignore the `examples` folder explicitly. See https://github.com/dependabot/dependabot-core/issues/4364

Maybe specifying the root directory ignores the example subfolder 🤷