### PR TITLE
chore: Cleanup log output from tests

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -33,7 +33,7 @@ export function createEffectsMiddleware(_r) {
 const logEffectError = (err) => {
   // As users can't get a handle on effects we need to report the error
   // eslint-disable-next-line no-console
-  console.log(err);
+  console.error(err);
 };
 
 export function createEffectHandler(def, _r, injections, _aC) {

--- a/tests/effect-on.test.js
+++ b/tests/effect-on.test.js
@@ -6,6 +6,7 @@ import {
   thunkOn,
   actionOn,
 } from '../src';
+import { mockConsole } from './utils';
 
 const wait = (time = 18) =>
   new Promise((resolve) => {
@@ -399,6 +400,8 @@ describe('errors', () => {
     const trackActions = trackActionsMiddleware();
     const store = createStore(model, { middleware: [trackActions] });
 
+    const restoreConsole = mockConsole(['error']);
+
     // ACT
     try {
       store.getActions().nested.setString('two');
@@ -425,6 +428,12 @@ describe('errors', () => {
       },
       { type: '@thunk.nested.doAsync(start)', payload: 'two' },
     ]);
+
+    // Verify that the error is logged to the console.
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalledWith(err);
+
+    restoreConsole();
   });
 });
 

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -11,6 +11,7 @@ import {
   useStoreRehydrated,
   createContextStore,
 } from '../src';
+import { mockConsole } from './utils';
 
 const wait = (time = 18) =>
   new Promise((resolve) => {
@@ -71,13 +72,16 @@ const sharedMakeStore = (
     storeConfig,
   );
 
+let restoreConsole = null;
 beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
+  restoreConsole = mockConsole(['warn']);
 });
 
 afterEach(() => {
   process.env.NODE_ENV = 'test';
+  restoreConsole();
 });
 
 test('default storage', async () => {


### PR DESCRIPTION
+ mocks & verify calls for `error` on failed effectOn
  - Removes unneccessary output from test & validates that `console.error` is called
+ mocks `warn` for persistance tests
  - Removes unneccessary output from test