### PR TITLE
Change to explicit filter for RecursiveState mapper type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -300,8 +300,12 @@ type StateMapper<StateModel extends object> = {
     : StateModel[P];
 };
 
+type FilterActionTypes<Model extends object> = {
+  [K in keyof Model as Model[K] extends ActionTypes ? never : K]: Model[K]
+};
+
 type RecursiveState<Model extends object> = StateMapper<
-  O.Filter<Model, ActionTypes>
+  FilterActionTypes<Model>
 >;
 
 /**


### PR DESCRIPTION
Say you have a model like this:

```
type MyState = {
    value: string
}

interface MyModel {
    myState: MyState

    setMyState: Action<MyModel, string>
}

const myModel: MyModel = {
    myState: {
        value: 'initial'
    },

    setMyState: action((state, payload) => {
        state.myState = {
            value: payload
        }
    })
}
```

If you try to "factor out" the `Action` type into its own type alias like this:

`type MyModelAction<TPayload = void> = Action<MyModel, TPayload>`

And then use it in your model:

```
...
interface MyModel {
    myState: MyState

    setMyState: MyModelAction<string> // <-- using our own type alias instead
}
...
```

ts-toolbelt's `O.Filter` works (used by the `RecursiveState` type), produces this error in your model instance:

`Type of property 'setMyState' circularly references itself in mapped type '{ [K in keyof MyModel]-?: { 1: never; 0: K; }[Extends<MyModel[K], ActionTypes>]; }'.ts(2615)`

This PR replaces `O.Filter` with an explicit filter using TypeScript's key remapping feature [here](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as)