### PR TITLE
Fix thunk and computed alias

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -535,7 +535,14 @@ export type Thunk<
   type: 'thunk';
   payload: Payload;
   result: Result;
+  [ModelTypeMarker]?: Model;
+  [InjectionsTypeMarker]?: Injections;
+  [StoreModelTypeMarker]?: StoreModel;
 };
+
+declare const ModelTypeMarker: unique symbol;
+declare const InjectionsTypeMarker: unique symbol;
+declare const StoreModelTypeMarker: unique symbol;
 
 /**
  * Declares an thunk against your model.
@@ -690,6 +697,8 @@ export type Computed<
 > = {
   type: 'computed';
   result: Result;
+  [ModelTypeMarker]?: Model;
+  [StoreModelTypeMarker]?: StoreModel;
 };
 
 type DefaultComputationFunc<Model extends object, Result> = (

--- a/index.d.ts
+++ b/index.d.ts
@@ -525,29 +525,17 @@ type Meta = {
  *   addTodo: Thunk<TodosModel, string>;
  * }
  */
-export type Thunk<
+export interface Thunk<
   Model extends object,
   Payload = undefined,
   Injections = any,
   StoreModel extends object = {},
   Result = any,
-> = {
+> {
   type: 'thunk';
   payload: Payload;
   result: Result;
-  [ModelTypeMarker]?: BivariantCapture<Model>;
-  [InjectionsTypeMarker]?: BivariantCapture<Injections>;
-  [StoreModelTypeMarker]?: BivariantCapture<StoreModel>;
-};
-
-/**
- * Allows the Thunk & Computed type aliases to "capture" the un-used type parameters in a bivariant position
- * so they can't cause any assignability issues, but are still "real" from TypeScript's perspective
- */
-type BivariantCapture<T> = { bivariant(m: T): void }['bivariant'];
-declare const ModelTypeMarker: unique symbol;
-declare const InjectionsTypeMarker: unique symbol;
-declare const StoreModelTypeMarker: unique symbol;
+}
 
 /**
  * Declares an thunk against your model.
@@ -695,16 +683,14 @@ export function actionOn<
  *   totalPrice: Computed<Model, number>;
  * }
  */
-export type Computed<
+export interface Computed<
   Model extends object,
   Result,
   StoreModel extends object = {},
-> = {
+> {
   type: 'computed';
   result: Result;
-  [ModelTypeMarker]?: BivariantCapture<Model>;
-  [StoreModelTypeMarker]?: BivariantCapture<StoreModel>;
-};
+}
 
 type DefaultComputationFunc<Model extends object, Result> = (
   state: State<Model>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -535,11 +535,16 @@ export type Thunk<
   type: 'thunk';
   payload: Payload;
   result: Result;
-  [ModelTypeMarker]?: Model;
-  [InjectionsTypeMarker]?: Injections;
-  [StoreModelTypeMarker]?: StoreModel;
+  [ModelTypeMarker]?: BivariantCapture<Model>;
+  [InjectionsTypeMarker]?: BivariantCapture<Injections>;
+  [StoreModelTypeMarker]?: BivariantCapture<StoreModel>;
 };
 
+/**
+ * Allows the Thunk & Computed type aliases to "capture" the un-used type parameters in a bivariant position
+ * so they can't cause any assignability issues, but are still "real" from TypeScript's perspective
+ */
+type BivariantCapture<T> = { bivariant(m: T): void }['bivariant']
 declare const ModelTypeMarker: unique symbol;
 declare const InjectionsTypeMarker: unique symbol;
 declare const StoreModelTypeMarker: unique symbol;
@@ -697,8 +702,8 @@ export type Computed<
 > = {
   type: 'computed';
   result: Result;
-  [ModelTypeMarker]?: Model;
-  [StoreModelTypeMarker]?: StoreModel;
+  [ModelTypeMarker]?: BivariantCapture<Model>;
+  [StoreModelTypeMarker]?: BivariantCapture<StoreModel>;
 };
 
 type DefaultComputationFunc<Model extends object, Result> = (

--- a/index.d.ts
+++ b/index.d.ts
@@ -301,7 +301,7 @@ type StateMapper<StateModel extends object> = {
 };
 
 type FilterActionTypes<Model extends object> = {
-  [K in keyof Model as Model[K] extends ActionTypes ? never : K]: Model[K]
+  [K in keyof Model as Model[K] extends ActionTypes ? never : K]: Model[K];
 };
 
 type RecursiveState<Model extends object> = StateMapper<
@@ -544,7 +544,7 @@ export type Thunk<
  * Allows the Thunk & Computed type aliases to "capture" the un-used type parameters in a bivariant position
  * so they can't cause any assignability issues, but are still "real" from TypeScript's perspective
  */
-type BivariantCapture<T> = { bivariant(m: T): void }['bivariant']
+type BivariantCapture<T> = { bivariant(m: T): void }['bivariant'];
 declare const ModelTypeMarker: unique symbol;
 declare const InjectionsTypeMarker: unique symbol;
 declare const StoreModelTypeMarker: unique symbol;

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,8 +300,12 @@ type StateMapper<StateModel extends object> = {
     : StateModel[P];
 };
 
+type FilterActionTypes<Model extends object> = {
+  [K in keyof Model as Model[K] extends ActionTypes ? never : K]: Model[K]
+};
+
 type RecursiveState<Model extends object> = StateMapper<
-  O.Filter<Model, ActionTypes>
+  FilterActionTypes<Model>
 >;
 
 /**

--- a/src/effects.js
+++ b/src/effects.js
@@ -33,7 +33,7 @@ export function createEffectsMiddleware(_r) {
 const logEffectError = (err) => {
   // As users can't get a handle on effects we need to report the error
   // eslint-disable-next-line no-console
-  console.log(err);
+  console.error(err);
 };
 
 export function createEffectHandler(def, _r, injections, _aC) {

--- a/tests/effect-on.test.js
+++ b/tests/effect-on.test.js
@@ -6,6 +6,7 @@ import {
   thunkOn,
   actionOn,
 } from '../src';
+import { mockConsole } from './utils';
 
 const wait = (time = 18) =>
   new Promise((resolve) => {
@@ -399,6 +400,8 @@ describe('errors', () => {
     const trackActions = trackActionsMiddleware();
     const store = createStore(model, { middleware: [trackActions] });
 
+    const restoreConsole = mockConsole(['error']);
+
     // ACT
     try {
       store.getActions().nested.setString('two');
@@ -425,6 +428,12 @@ describe('errors', () => {
       },
       { type: '@thunk.nested.doAsync(start)', payload: 'two' },
     ]);
+
+    // Verify that the error is logged to the console.
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalledWith(err);
+
+    restoreConsole();
   });
 });
 

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -11,6 +11,7 @@ import {
   useStoreRehydrated,
   createContextStore,
 } from '../src';
+import { mockConsole } from './utils';
 
 const wait = (time = 18) =>
   new Promise((resolve) => {
@@ -71,13 +72,16 @@ const sharedMakeStore = (
     storeConfig,
   );
 
+let restoreConsole = null;
 beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
+  restoreConsole = mockConsole(['warn']);
 });
 
 afterEach(() => {
   process.env.NODE_ENV = 'test';
+  restoreConsole();
 });
 
 test('default storage', async () => {

--- a/tests/typescript/complex-store-inheritance.ts
+++ b/tests/typescript/complex-store-inheritance.ts
@@ -1,0 +1,31 @@
+import { Thunk } from 'easy-peasy';
+
+type Injections = any;
+
+type ISomeOtherModel = {};
+
+interface IModelA<TStore extends ISomeOtherModel> {
+  commitSomething: Thunk<
+    IModelAStoreModel<TStore>,
+    void,
+    Injections,
+    IModelAStoreModel<TStore>
+  >;
+}
+
+// IModelAStoreModel is generic, and requires the root store as input
+type IModelAStoreModel<TStore extends ISomeOtherModel> = IModelA<TStore> &
+  ISomeOtherModel & {
+    onSomethingLoaded: Thunk<TStore, any>;
+  };
+
+// IModelBStoreModel is not generic, and is based on IModelAStoreModel, but it does not care about the generic type
+// of IModelAStoreModel (thus it is just passing`any` to`IModelAStoreModel`)
+interface IModelBStoreModel extends IModelAStoreModel<any> {}
+
+// ❌ Fails here 👇
+// > Interface 'IStoreModel' cannot simultaneously extend types 'IModelAStoreModel<IStoreModel>' and 'IModelBStoreModel'.
+// >   Named property 'commitSomething' of types 'IModelAStoreModel<IStoreModel>' and 'IModelBStoreModel' are not identical.
+interface IStoreModel
+  extends IModelAStoreModel<IStoreModel>,
+    IModelBStoreModel {}

--- a/tests/typescript/complex-store-inheritance.ts
+++ b/tests/typescript/complex-store-inheritance.ts
@@ -23,9 +23,7 @@ type IModelAStoreModel<TStore extends ISomeOtherModel> = IModelA<TStore> &
 // of IModelAStoreModel (thus it is just passing`any` to`IModelAStoreModel`)
 interface IModelBStoreModel extends IModelAStoreModel<any> {}
 
-// ❌ Fails here 👇
-// > Interface 'IStoreModel' cannot simultaneously extend types 'IModelAStoreModel<IStoreModel>' and 'IModelBStoreModel'.
-// >   Named property 'commitSomething' of types 'IModelAStoreModel<IStoreModel>' and 'IModelBStoreModel' are not identical.
+// IStoreModel should be allowed to extend both IModelAStoreModel & IModelBStoreModel
 interface IStoreModel
   extends IModelAStoreModel<IStoreModel>,
     IModelBStoreModel {}


### PR DESCRIPTION
This is a followup to [this](https://github.com/ctrlplusb/easy-peasy/pull/790) PR.

Suppose you had a model where you had factored out the `Thunk` and `Computed` types into their own aliases like this:

```
type MyModelAction<TPayload = void> = Action<MyModel, TPayload>
type MyModelComputed<TResult> = Computed<MyModel, TResult>
type MyModelThunk<TPayload = undefined, TResult = any> = Thunk<MyModel, TPayload, any, {}, Promise<TResult>>

type MyState = {
    value: string
}

type MyThunkPayload = { data: string }

interface MyModel {
    myState: MyState

    myComputed: MyModelComputed<number>

    setMyState: MyModelAction<string>

    myThunk: MyModelThunk<MyThunkPayload, boolean>

}

const myModel: MyModel = {
    myState: {
        value: 'initial'
    },

    setMyState: action((state, payload) => {
        state.myState = {
            value: payload
        }
    }),

    myComputed: computed(state => state.myState.value.length),

    myThunk: thunk(async (actions, payload) => {
        actions.setMyState('a')
        // some kind of await
        return true
    })
}
```

Since the `Thunk` and `Computed` types don't actually use the `Model` type parameter in their resulting type, it is "lost" when we make a type alias wrappers. This means the `computed()` and `thunk()` generic functions infer their type parameters like this when attempting to use them on the model instance:

`computed<{}, any, {}, StateResolvers<{}, {}>>`

`thunk<{}, MyThunkPayload, any, {}, Promise<true>>`

Whereas we would expect them to be inferred like this:

`computed<MyModel, number, {}, StateResolvers<MyModel, {}>>`

`thunk<MyModel, MyThunkPayload, any, {}, Promise<true>>`


 The result on the model instance is:

```
// Property 'myState' does not exist on type 'StateMapper<_Pick<{}, never>>'.
myComputed: computed(state => state.myState.value.length),
```

and 

```
//Property 'setMyState' does not exist on type 'Actions<{}>'
actions.setMyState('a')
```

This PR addresses this by adding type markers which forces TypeScript to capture these type variables, fixing the target typing on the model instance.

This has also been used to capture the `StoreModel` and `Injections` type parameters.

A concern I have is if someone was using these types in an unconventional way e.g.

Before:

```
// "type" | "result"
type Before = keyof Computed<any, any>;
```

After:
```
// typeof ModelTypeMarker | typeof StoreModelTypeMarker | "result" | "type"
type After = keyof Computed<any, any>;
```

So in this sense it's a breaking change.

Fixes: https://github.com/ctrlplusb/easy-peasy/issues/634