### PR TITLE
fix: allow `Unstable_EffectOn` type to be aliased

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -698,13 +698,13 @@ export function computed<
 
 // #region EffectOn
 
-export type Unstable_EffectOn<
+export interface Unstable_EffectOn<
   Model extends object = {},
   StoreModel extends object = {},
   Injections = any,
-> = {
+> {
   type: 'effectOn';
-};
+}
 
 type Change<Resolvers extends StateResolvers<any, any>> = {
   prev: ExtractReturnTypes<Resolvers>;

--- a/tests/typescript/external-type-defs.ts
+++ b/tests/typescript/external-type-defs.ts
@@ -1,5 +1,15 @@
-import { action, Action, computed, Computed, thunk, Thunk } from 'easy-peasy';
+import {
+  action,
+  Action,
+  computed,
+  Computed,
+  thunk,
+  Thunk,
+  unstable_effectOn,
+  Unstable_EffectOn,
+} from 'easy-peasy';
 
+type MyModelEffectOn = Unstable_EffectOn<MyModel>;
 type MyModelAction<TPayload = void> = Action<MyModel, TPayload>;
 type MyModelComputed<TResult> = Computed<MyModel, TResult>;
 type MyModelThunk<TPayload = undefined, TResult = any> = Thunk<
@@ -24,6 +34,8 @@ interface MyModel {
   setMyState: MyModelAction<string>;
 
   myThunk: MyModelThunk<MyThunkPayload, boolean>;
+
+  myEffectOn: MyModelEffectOn;
 }
 
 const myModel: MyModel = {
@@ -44,4 +56,11 @@ const myModel: MyModel = {
     // some kind of await
     return true;
   }),
+
+  myEffectOn: unstable_effectOn(
+    [(state) => state.myState.value],
+    (actions, change) => {
+      // do something
+    },
+  ),
 };

--- a/tests/typescript/issue802.ts
+++ b/tests/typescript/issue802.ts
@@ -1,0 +1,88 @@
+import {
+  Unstable_EffectOn,
+  unstable_effectOn,
+  Action,
+  action,
+} from 'easy-peasy';
+
+type AppEffectOn<TModel extends object> = Unstable_EffectOn<
+  TModel,
+  StoreModel,
+  Injections
+>;
+
+interface Injections {
+  doSomething: () => Promise<void>;
+}
+
+interface TodosModel {
+  items: { id: number; text: string }[];
+  foo: string;
+  setFoo: Action<TodosModel, string>;
+  onStateChanged: AppEffectOn<TodosModel>;
+}
+
+interface HelloModel {
+  name: string;
+  sayHelloTo: Action<HelloModel, string>;
+  onStateChanged: AppEffectOn<HelloModel>;
+}
+
+interface StoreModel {
+  hello: HelloModel;
+  todos: TodosModel;
+  rootData: number;
+}
+
+const model: StoreModel = {
+  rootData: 42,
+  hello: {
+    name: 'Arthur',
+    sayHelloTo: action((state, payload) => {
+      state.name = payload;
+    }),
+    onStateChanged: unstable_effectOn(
+      [(state) => state.name],
+      (_, __, helpers) => {
+        console.log(`Hello, ${helpers.getState().name}`);
+      },
+    ),
+  },
+  todos: {
+    items: [],
+    foo: 'bar',
+    setFoo: action((state, payload) => {
+      state.foo = payload;
+    }),
+    onStateChanged: unstable_effectOn(
+      [
+        (state) => state.items,
+        (state) => state.foo,
+        (state, storeState) => storeState.rootData,
+      ],
+      (actions, change, helpers) => {
+        actions.setFoo('bar');
+
+        const [prevItems, prevFoo, prevRootData] = change.prev;
+        prevItems[0].text;
+        const baz = `${prevFoo}bar`;
+        prevRootData + 2;
+
+        const [currentItems, currentFoo, currentRootData] = change.current;
+        const qux = `${currentFoo}bar`;
+        currentItems[0].text;
+        currentRootData + 2;
+
+        helpers.injections.doSomething().then(() => {});
+        helpers.dispatch.todos.setFoo('plop');
+        helpers.getState().items[0].id + 2;
+        helpers.getStoreActions().todos.setFoo('plop');
+        helpers.getStoreState().rootData + 2;
+        helpers.meta.parent[0].toLowerCase();
+        helpers.meta.path[0].toLowerCase();
+
+        return () => console.log('dispose');
+      },
+    ),
+  },
+};


### PR DESCRIPTION
- Following up on the work completed in #790 and #791, defines the `Unstable_EffectOn` type as an interface rather than a type so that unused type params don't get "lost" when the type is aliased. 
- Adds/updates TypeScript tests

fixes #802