### PR TITLE
fix: types and docs related to action config obj

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -593,9 +593,8 @@ export type Action<Model extends object, Payload = void> = {
   result: void | State<Model>;
 };
 
-
 /**
-  * @param {boolean} [immer=true] - If true, the action will be wrapped in an immer produce call. Otherwise, the action will update the state directly.
+ * @param {boolean} [immer=true] - If true, the action will be wrapped in an immer produce call. Otherwise, the action will update the state directly.
  **/
 interface Config {
   immer?: boolean;
@@ -618,7 +617,8 @@ interface Config {
  * });
  */
 export function action<Model extends object = {}, Payload = any>(
-  action: (state: State<Model>, payload: Payload, config?: Config) => void | State<Model>,
+  action: (state: State<Model>, payload: Payload) => void | State<Model>,
+  config?: Config,
 ): Action<Model, Payload>;
 
 // #endregion
@@ -774,7 +774,10 @@ export type Reducer<State = any, Action extends ReduxAction = AnyAction> = {
  *   })
  * });
  */
-export function reducer<State>(state: ReduxReducer<State>, config?: Config): Reducer<State>;
+export function reducer<State>(
+  reducer: ReduxReducer<State>,
+  config?: Config,
+): Reducer<State>;
 
 // #endregion
 

--- a/tests/typescript/action.ts
+++ b/tests/typescript/action.ts
@@ -12,9 +12,12 @@ interface Model {
 
 const todos: TodosModel = {
   items: [],
-  add: action((state, payload) => {
-    state.items.push(payload);
-  }),
+  add: action(
+    (state, payload) => {
+      state.items.push(payload);
+    },
+    { immer: true },
+  ),
   clear: action((state) => {
     state.items = [];
   }),

--- a/tests/typescript/listener-action.ts
+++ b/tests/typescript/listener-action.ts
@@ -116,3 +116,14 @@ const valid7: ActionOn<ListeningModel> = actionOn(
     state.logs.push(target.payload);
   },
 );
+
+const valid8: ActionOn<ListeningModel> = actionOn(
+  (actions) => [actions.doActionString],
+  (state, target) => ({
+    ...state,
+    logs: [...state.logs, target.payload]
+  }),
+  {
+    immer: false
+  }
+);

--- a/website/docs/docs/api/action.md
+++ b/website/docs/docs/api/action.md
@@ -48,15 +48,17 @@ An `action` is a function that is described below.
 
     The payload, if any, that was provided to the
     [action](/docs/api/action.html) when it was dispatched.
-  
-  - `config` (Object)
 
-    The config object that was provided to the
-    [action](/docs/api/action.html) when it was dispatched. 
-    - `immer` (Boolean)
-      Whether to use `immer` to update the state. Defaults to `true`.
-      
-      You may want to consider disabling immer when dealing with a large/deep data structure within your state. Immer does unfortunately have an overhead as it wraps data in a Proxy solution for the mutation based updates to work. We would suggest only using this escape hatch if you are noticing any performance degradation.
+- `config` (Object)
+
+  An optional object to configure the [action](/docs/api/action.html).
+
+  - `immer` (Boolean) Whether to use `immer` to update the state. Defaults to
+    `true`. You may want to consider disabling immer when dealing with a
+    large/deep data structure within your state. Immer does unfortunately have
+    an overhead as it wraps data in a Proxy solution for the mutation based
+    updates to work. We would suggest only using this escape hatch if you are
+    noticing any performance degradation.
 
 ## Tutorial
 
@@ -83,12 +85,45 @@ immutable updates.
 To get around this you can use the [debug](/docs/api/debug.html) utility.
 
 ```javascript
-import { debug } from 'easy-peasy';
+import { action, debug } from 'easy-peasy';
 
 const model = {
   myAction: action((state, payload) => {
     console.log(debug(state));
   }),
+};
+```
+
+### Disabling Immer
+
+When dealing with a large/deep data structures within your state, you may want
+to consider disabling Immer for the [actions](/docs/api/action.html) that update them. Immer does
+unfortunately have an overhead as it wraps data in a Proxy solution for the
+mutation based updates to work. We would suggest only using this escape hatch if
+you are noticing any performance degradation.
+
+When disabling Immer, you need to explicitly return `state` from your [action](/docs/api/action.html) and
+manage immutability yourself:
+
+```javascript
+import { action } from 'easy-peasy';
+
+const model = {
+  bigData: {/*...*/}, // 👈 arbitrarily large / nested data structure
+  updateBigData: action(
+    (state, payload) => {
+      return {
+        ...state,
+        bigData: {
+          ...state.bigData,
+          ...payload,
+        },
+      };
+    },
+    {
+      immer: false,
+    }
+  ),
 };
 ```
 

--- a/website/docs/docs/api/action.md
+++ b/website/docs/docs/api/action.md
@@ -96,7 +96,7 @@ const model = {
 
 ### Disabling Immer
 
-When dealing with a large/deep data structures within your state, you may want
+When dealing with large/deeply nested data structures within your state, you may want
 to consider disabling Immer for the [actions](/docs/api/action.html) that update them. Immer does
 unfortunately have an overhead as it wraps data in a Proxy solution for the
 mutation based updates to work. We would suggest only using this escape hatch if
@@ -109,7 +109,7 @@ manage immutability yourself:
 import { action } from 'easy-peasy';
 
 const model = {
-  bigData: {/*...*/}, // 👈 arbitrarily large / nested data structure
+  bigData: {/*...*/}, // 👈 arbitrarily large/deeply nested data
   updateBigData: action(
     (state, payload) => {
       return {

--- a/website/docs/docs/api/reducer.md
+++ b/website/docs/docs/api/reducer.md
@@ -51,13 +51,18 @@ The `reducer` function is described below.
 
       Any payload that was provided to the action.
 
-  - `config` (Object)
+- `config` (Object)
 
-    The config object that was provided to the action when it was dispatched. 
-    - `immer` (Boolean)
-      Whether to use `immer` to update the state. Defaults to `true`.
-      
-      You may want to consider disabling immer when dealing with a large/deep data structure within your state. Immer does unfortunately have an overhead as it wraps data in a Proxy solution for the mutation based updates to work. We would suggest only using this escape hatch if you are noticing any performance degradation.
+  An optional object to configure the [reducer](/docs/api/reducer.html).
+
+  - `immer` (Boolean) Whether to use `immer` to update the state. Defaults to
+    `true`.
+
+    You may want to consider disabling immer when dealing with a large/deep data
+    structure within your state. Immer does unfortunately have an overhead as it
+    wraps data in a Proxy solution for the mutation based updates to work. We
+    would suggest only using this escape hatch if you are noticing any
+    performance degradation.
 
 ## Example
 
@@ -73,7 +78,7 @@ const store = createStore({
   counter: reducer((state = 1, action) => {
     switch (action.type) {
       case 'INCREMENT':
-        state + 1;
+        return state + 1;
       default:
         return state;
     }


### PR DESCRIPTION
**This PR:**
- Is related to the work completed in #781 and is mainly to update docs and types related to configuring actions / disabling Immer. The config object is the second argument to `action` and `reducer` and both the types and docs needed to be updated to reflect this.
- Adds an example in the action docs for disabling Immer to make it clearer immutability needs to be managed manually when `immer` is set to `false`. ([preview docs](https://easy-peasy-git-fix-immer-config-types-docs-ctrlplusb.vercel.app/docs/api/action.html#disabling-immer)).
- Fixes a fall-through case in the `reducer` example in the docs
- Updates a few tests related to disabling Immer.
