### PR TITLE
fix: `unstable_effectOn` actions for nested model

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prepublish": "yarn run build",
     "test": "jest",
     "test:source": "jest --modulePathIgnorePatterns=typescript.test.js",
+    "test:source:watch": "yarn test:source -- --watch",
     "test:coverage": "yarn run test -- --coverage",
     "test:coverage:deploy": "yarn run test:coverage && codecov",
     "prepare": "husky install"

--- a/src/effects.js
+++ b/src/effects.js
@@ -37,8 +37,6 @@ const logEffectError = (err) => {
 };
 
 export function createEffectHandler(def, _r, injections, _aC) {
-  const actions = get(def.meta.parent, _aC);
-
   let dispose;
 
   return (change) => {
@@ -63,6 +61,7 @@ export function createEffectHandler(def, _r, injections, _aC) {
       }
     }
 
+    const actions = get(def.meta.parent, _aC);
     const effectResult = def.fn(actions, change, helpers);
 
     if (isPromise(effectResult)) {
@@ -163,4 +162,3 @@ export function createEffectActionsCreator(def, _r, effectHandler) {
 
   return actionCreator;
 }
-

--- a/tests/effect-on.test.js
+++ b/tests/effect-on.test.js
@@ -138,6 +138,34 @@ test('it receives the local actions', () => {
   expect(store.getState().fired).toBe(true);
 });
 
+test('it receives the local actions for nested model', () => {
+  // ARRANGE
+  const store = createStore({
+    nested: {
+      fired: false,
+      todos: [],
+      onTodosChanged: unstable_effectOn([(state) => state.todos], (actions) => {
+        actions.setFired(true);
+      }),
+      addTodo: action((state, payload) => {
+        state.todos.push(payload);
+      }),
+      setFired: action((state, payload) => {
+        state.fired = payload;
+      }),
+    }
+  });
+
+  // ASSERT
+  expect(store.getState().nested.fired).toBe(false);
+
+  // ACT
+  store.getActions().nested.addTodo('add onEffect api');
+
+  // ASSERT
+  expect(store.getState().nested.fired).toBe(true);
+});
+
 test('change argument is as expected', () => {
   // ARRANGE
   let actualChange;


### PR DESCRIPTION
* move `actions` definition inside the effect handler that's returned from `createEffectHandler` so that its evaluated at the time the effect handler is called, not at the time the model is defined, which can cause a potentially undefined `actions` object depending on the order that actions and effects are defined on the model when a model is nested

* update tests  with peviously failing example from #597

closes #597