### PR TITLE
feat: Pass full state to persist transforms

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1032,8 +1032,8 @@ export interface PersistStorage {
 }
 
 export interface Transformer {
-  in?: (data: any, key: string) => any;
-  out?: (data: any, key: string) => any;
+  in?: (data: any, key: string, fullState?: any) => any;
+  out?: (data: any, key: string, fullState?: any) => any;
 }
 
 export interface PersistConfig<Model extends object> {
@@ -1050,8 +1050,8 @@ export interface TransformConfig {
 }
 
 export function createTransform(
-  inbound?: (data: any, key: string) => any,
-  outbound?: (data: any, key: string) => any,
+  inbound?: (data: any, key: string, fullState?: any) => any,
+  outbound?: (data: any, key: string, fullState?: any) => any,
   config?: TransformConfig,
 ): Transformer;
 

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -57,7 +57,7 @@ function createStorageWrapper(storage, transformers = []) {
     if (transformers.length > 0 && data != null && typeof data === 'object') {
       Object.keys(data).forEach((key) => {
         data[key] = transformers.reduce(
-          (acc, cur) => cur.in(acc, key),
+          (acc, cur) => cur.in(acc, key, data),
           data[key],
         );
       });
@@ -80,7 +80,7 @@ function createStorageWrapper(storage, transformers = []) {
     ) {
       Object.keys(result).forEach((key) => {
         result[key] = outTransformers.reduce(
-          (acc, cur) => cur.out(acc, key),
+          (acc, cur) => cur.out(acc, key, result),
           result[key],
         );
       });

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -645,12 +645,14 @@ test('clear', async () => {
 test('transformers', async () => {
   // ARRANGE
   const upperCaseTransformer = createTransform(
-    (data, key) => {
+    (data, key, fullState) => {
       expect(key).toBe('one');
+      expect(fullState).toEqual({"one": "item one", "two": "item two"})
       return data.toUpperCase();
     },
-    (data, key) => {
+    (data, key, fullState) => {
       expect(key).toBe('one');
+      expect(fullState).toEqual({"one": "_ITEM ONE_", "two": "item two"})
       return data.toLowerCase();
     },
     {
@@ -659,12 +661,14 @@ test('transformers', async () => {
   );
 
   const padTransformer = createTransform(
-    (data, key) => {
+    (data, key, fullState) => {
       expect(key).toBe('one');
+      expect(fullState).toEqual({"one": "item one", "two": "item two"})
       return `_${data}_`;
     },
-    (data, key) => {
+    (data, key, fullState) => {
       expect(key).toBe('one');
+      expect(fullState).toEqual({"one": "_ITEM ONE_", "two": "item two"})
       return data.substr(1, data.length - 2);
     },
     {

--- a/tests/typescript/persist.tsx
+++ b/tests/typescript/persist.tsx
@@ -38,7 +38,7 @@ createTransform(
   (data, key) => `${key}foo`,
 );
 
-createTransform((data, key) => `${key}foo`);
+createTransform((data, key, fullState) => `${key}foo`);
 
 createTransform(undefined, (data, key) => `${key}foo`, {
   whitelist: ['foo'],

--- a/website/docs/docs/api/create-transform.md
+++ b/website/docs/docs/api/create-transform.md
@@ -14,11 +14,11 @@ This helper has been directly copied from [`redux-persist`](https://github.com/r
 
 The function accepts the following arguments:
 
-  - `inbound` (data: any, key: string) => any; *optional*
+  - `inbound` (data: any, key: string, fullState: any) => any; *optional*
 
     This function will be executed against data prior to it being persisted by the configured storage engine.
-  
-  - `outbound` (data: any, key: string) => any; *optional*
+
+  - `outbound` (data: any, key: string, fullState: any) => any; *optional*
 
     This function will be executed against data prior after it is extracted from the configured storage engine.
 
@@ -29,7 +29,7 @@ The function accepts the following arguments:
      - `whitelist` Array&lt;string&gt;; *optional*
 
        The data keys that this transformer would apply to.
-     
+
      - `blacklist` Array&lt;string&gt;; *optional*
 
        The data keys that this transformer would not apply to.


### PR DESCRIPTION
Noticed a slight divergence from the `redux-persist` [transform api](https://github.com/rt2zz/redux-persist/blob/master/src/createTransform.ts#L26-L33), where there they pass the full state along with the `in` and `out` calls. This also aligns with the api as seen in `create-transform` code in the easy-peasy [codebase](https://github.com/ctrlplusb/easy-peasy/blob/master/src/create-transform.js#L17-L24). 

Now the api is: 
```tsx
in: (state, key, fullState) => { ... }
out: (state, key, fullState) => { ... }
```