### PR TITLE
feat: Add persisted state migrations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1040,6 +1040,10 @@ export interface PersistConfig<Model extends object> {
   allow?: Array<keyof Model>;
   deny?: Array<keyof Model>;
   mergeStrategy?: 'mergeDeep' | 'mergeShallow' | 'overwrite';
+  migrations?: {
+    migrationVersion: number;
+    [key: number]: (state: Partial<Model & { [key: string | number]: any }>) => void;
+  }
   storage?: 'localStorage' | 'sessionStorage' | PersistStorage;
   transformers?: Array<Transformer>;
 }

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -6,7 +6,7 @@ export const migrate = (
 ) => {
   setAutoFreeze(false);
 
-  let version = data._migrationVersion ?? -1;
+  let version = data._migrationVersion ?? 0;
   const toVersion = migrations.migrationVersion
 
   if (typeof version !== "number" || typeof toVersion !== 'number') {

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -6,10 +6,10 @@ export const migrate = (
 ) => {
   setAutoFreeze(false);
 
-  let version = data._migrationVersion || -1;
+  let version = data._migrationVersion ?? -1;
   const toVersion = migrations.migrationVersion
 
-  if (typeof toVersion !== 'number') {
+  if (typeof version !== "number" || typeof toVersion !== 'number') {
     throw new Error('No migration version found');
   }
 

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,0 +1,31 @@
+import { produce, setAutoFreeze } from 'immer';
+
+export const migrate = (
+  data,
+  migrations,
+) => {
+  setAutoFreeze(false);
+
+  let version = data._migrationVersion || -1;
+  const toVersion = migrations.migrationVersion
+
+  if (typeof toVersion !== 'number') {
+    throw new Error('No migration version found');
+  }
+
+  while (version < toVersion) {
+    const nextVersion = version + 1;
+    const migrator = migrations[nextVersion];
+
+    if (!migrator) {
+      throw new Error(`No migrator found for \`migrationVersion\` ${nextVersion}`);
+    }
+
+    data = produce(data, migrator);
+    data._migrationVersion = nextVersion;
+    version = data._migrationVersion;
+  }
+
+  setAutoFreeze(true);
+  return data;
+}

--- a/tests/migrations.test.js
+++ b/tests/migrations.test.js
@@ -1,0 +1,142 @@
+/* eslint-disable no-useless-computed-key */
+import { migrate } from '../src/migrations';
+
+test('leaves an object untouched if there are no migrations pending', () => {
+  // ARRANGE
+  const result = migrate(
+    {
+      _migrationVersion: 1,
+      value: 'untouched',
+    },
+    {
+      migrationVersion: 1,
+
+      [1]: (state) => {
+        state.value = 'modified';
+      },
+    },
+  );
+
+  // ASSERT
+  expect(result.value).toBe('untouched');
+  expect(result._migrationVersion).toBe(1);
+});
+
+test('applies a migration if there is one pending', () => {
+  // ARRANGE
+  const result = migrate(
+    {
+      _migrationVersion: 0,
+      value: 'untouched',
+    },
+    {
+      migrationVersion: 1,
+
+      [1]: (state) => {
+        state.value = 'modified';
+      },
+    },
+  );
+
+  expect(result.value).toBe('modified');
+  expect(result._migrationVersion).toBe(1);
+});
+
+test('applies many migrations if there are many pending', () => {
+  // ARRANGE
+  const result = migrate(
+    {
+      _migrationVersion: 0,
+    },
+    {
+      migrationVersion: 4,
+
+      [0]: (state) => {
+        state.zero = true;
+      },
+      [1]: (state) => {
+        state.one = true;
+      },
+      [2]: (state) => {
+        state.two = true;
+      },
+      [3]: (state) => {
+        state.three = true;
+      },
+      [4]: (state) => {
+        state.four = true;
+      },
+      [5]: (state) => {
+        state.five = true;
+      },
+    },
+  );
+
+  // ASSERT
+  expect(result.zero).toBe(undefined);
+  expect(result.one).toBe(true);
+  expect(result.two).toBe(true);
+  expect(result.three).toBe(true);
+  expect(result.four).toBe(true);
+  expect(result.five).toBe(undefined);
+  expect(result._migrationVersion).toBe(4);
+});
+
+test('throws an error if there is no valid version', () => {
+  // ARRANGE
+  expect(() => {
+    migrate(
+      {
+        _migrationVersion: '0',
+      },
+      {
+        migrationVersion: 1,
+
+        [1]: (state) => {
+          state.zero = true;
+        },
+      },
+    );
+    // ASSERT
+  }).toThrowError(`No migration version found`);
+});
+
+test('throws an error if there is no valid migration', () => {
+  // ARRANGE
+  expect(() => {
+    migrate(
+      {
+        _migrationVersion: 0,
+      },
+      {
+        migrationVersion: 1,
+
+        [0]: (state) => {
+          state.zero = true;
+        },
+      },
+    );
+    // ASSERT
+  }).toThrowError('No migrator found for `migrationVersion` 1');
+});
+
+test('guarantees that the version number ends up correct', () => {
+  // ARRANGE
+  const result = migrate(
+    {
+      _migrationVersion: 0,
+      value: 'untouched',
+    },
+    {
+      migrationVersion: 1,
+      [1]: (state) => {
+        state.value = 'modified';
+        state._migrationVersion = 5;
+      },
+    },
+  );
+
+  // ASSERT
+  expect(result.value).toBe('modified');
+  expect(result._migrationVersion).toBe(1);
+});

--- a/tests/migrations.test.js
+++ b/tests/migrations.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-useless-computed-key */
 import { migrate } from '../src/migrations';
 
 test('leaves an object untouched if there are no migrations pending', () => {
@@ -11,7 +10,7 @@ test('leaves an object untouched if there are no migrations pending', () => {
     {
       migrationVersion: 1,
 
-      [1]: (state) => {
+      1: (state) => {
         state.value = 'modified';
       },
     },
@@ -26,13 +25,12 @@ test('applies a migration if there is one pending', () => {
   // ARRANGE
   const result = migrate(
     {
-      _migrationVersion: 0,
       value: 'untouched',
     },
     {
       migrationVersion: 1,
 
-      [1]: (state) => {
+      1: (state) => {
         state.value = 'modified';
       },
     },
@@ -51,22 +49,22 @@ test('applies many migrations if there are many pending', () => {
     {
       migrationVersion: 4,
 
-      [0]: (state) => {
+      0: (state) => {
         state.zero = true;
       },
-      [1]: (state) => {
+      1: (state) => {
         state.one = true;
       },
-      [2]: (state) => {
+      2: (state) => {
         state.two = true;
       },
-      [3]: (state) => {
+      3: (state) => {
         state.three = true;
       },
-      [4]: (state) => {
+      4: (state) => {
         state.four = true;
       },
-      [5]: (state) => {
+      5: (state) => {
         state.five = true;
       },
     },
@@ -92,7 +90,7 @@ test('throws an error if there is no valid version', () => {
       {
         migrationVersion: 1,
 
-        [1]: (state) => {
+        1: (state) => {
           state.zero = true;
         },
       },
@@ -111,7 +109,7 @@ test('throws an error if there is no valid migration', () => {
       {
         migrationVersion: 1,
 
-        [0]: (state) => {
+        0: (state) => {
           state.zero = true;
         },
       },
@@ -129,7 +127,7 @@ test('guarantees that the version number ends up correct', () => {
     },
     {
       migrationVersion: 1,
-      [1]: (state) => {
+      1: (state) => {
         state.value = 'modified';
         state._migrationVersion = 5;
       },

--- a/tests/migrations.test.js
+++ b/tests/migrations.test.js
@@ -80,6 +80,35 @@ test('applies many migrations if there are many pending', () => {
   expect(result._migrationVersion).toBe(4);
 });
 
+test('applies migrations and deletes old values', () => {
+  // ARRANGE
+  const result = migrate(
+    {
+      _migrationVersion: 0,
+      session: "session",
+    },
+    {
+      migrationVersion: 2,
+
+      1: (state) => {
+        state.userSession = state.session;
+        delete state.session;
+      },
+
+      2: (state) => {
+        state.domainSession = state.userSession;
+        delete state.userSession;
+      },
+    },
+  );
+
+  // ASSERT
+  expect(result.session).toBe(undefined);
+  expect(result.userSession).toBe(undefined);
+  expect(result.domainSession).toBe('session');
+  expect(result._migrationVersion).toBe(2);
+});
+
 test('throws an error if there is no valid version', () => {
   // ARRANGE
   expect(() => {

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -774,6 +774,48 @@ test('transformers order', async () => {
   });
 });
 
+test('migrations', async () => {
+  // ARRANGE
+  const memoryStorage = createMemoryStorage({
+    '[EasyPeasyStore][0]': {
+      foo: "foo-updated",
+      migrationConfict: "error"
+    },
+  });
+
+  const makeStore = () =>
+    createStore(
+      persist(
+        {
+          foo: {
+            bar: "bar",
+          },
+          bar: "bar",
+        },
+        {
+          storage: memoryStorage,
+          migrations: {
+            migrationVersion: 1,
+
+            0: (state) => {
+              state.foo = { bar: state.foo }
+            },
+            1: (state) => {
+              delete state.migrationConfict;
+            },
+          }
+        },
+      ),
+    );
+
+  const store = makeStore();
+  await store.persist.resolveRehydration();
+
+  // ASSERT
+  expect(store.getState().foo.bar).toBe('foo-updated')
+  expect(store.getState().migrationConfict).toBeUndefined();
+})
+
 test('multiple stores', async () => {
   // ARRANGE
   const memoryStorage = createMemoryStorage();

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -778,8 +778,8 @@ test('migrations', async () => {
   // ARRANGE
   const memoryStorage = createMemoryStorage({
     '[EasyPeasyStore][0]': {
-      foo: "foo-updated",
-      migrationConfict: "error"
+      session: "session",
+      user: "User Name",
     },
   });
 
@@ -787,10 +787,10 @@ test('migrations', async () => {
     createStore(
       persist(
         {
-          foo: {
-            bar: "bar",
+          user: {
+            name: null,
+            session: null
           },
-          bar: "bar",
         },
         {
           storage: memoryStorage,
@@ -798,10 +798,13 @@ test('migrations', async () => {
             migrationVersion: 2,
 
             1: (state) => {
-              state.foo = { bar: state.foo }
+              state.user = { name: state.user }
+              state.userSession = state.session;
+              delete state.session;
             },
             2: (state) => {
-              delete state.migrationConfict;
+              state.user.session = state.userSession;
+              delete state.userSession;
             },
           }
         },
@@ -812,8 +815,10 @@ test('migrations', async () => {
   await store.persist.resolveRehydration();
 
   // ASSERT
-  expect(store.getState().foo.bar).toBe('foo-updated')
-  expect(store.getState().migrationConfict).toBeUndefined();
+  expect(store.getState().user.name).toBe('User Name')
+  expect(store.getState().user.session).toBe('session')
+  expect(store.getState().session).toBeUndefined();
+  expect(store.getState().userSession).toBeUndefined();
 })
 
 test('multiple stores', async () => {

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -795,12 +795,12 @@ test('migrations', async () => {
         {
           storage: memoryStorage,
           migrations: {
-            migrationVersion: 1,
+            migrationVersion: 2,
 
-            0: (state) => {
+            1: (state) => {
               state.foo = { bar: state.foo }
             },
-            1: (state) => {
+            2: (state) => {
               delete state.migrationConfict;
             },
           }

--- a/tests/typescript/persist.tsx
+++ b/tests/typescript/persist.tsx
@@ -24,6 +24,22 @@ const model = persist(
 
 `${model.foo}baz`;
 
+persist(
+  {
+    foo: 'bar',
+  },
+  {
+    migrations: {
+      migrationVersion: 1,
+
+      1: (state) => {
+        state.foo = 'bar';
+        delete state.migrationConflict
+      }
+    },
+  },
+);
+
 createTransform(
   (data, key) => `${key}foo`,
   (data, key) => `${key}foo`,

--- a/website/docs/docs/api/persist.md
+++ b/website/docs/docs/api/persist.md
@@ -73,7 +73,10 @@ Below is the API of the `persist` helper function.
 
   - `migrations` (Object, _optional_)
 
-    This config is used to transform persisted store state from one representation to another. This object is keyed by version numbers, with migration functions attached to each version. A `migrationVersion` is also required for this object, to specify which version to target.
+    This config is used to transform persisted store state from one
+    representation to another. This object is keyed by version numbers, with
+    migration functions attached to each version. A `migrationVersion` is also
+    required for this object, to specify which version to target.
 
     ```ts
     persist(
@@ -265,8 +268,22 @@ have persisted state based on a previous version of your store model. The user's
 persisted state may not align with that of your new store model, which could
 result in errors when a component tries to consume/update the store.
 
-Easy Peasy does its best to try and minimize / alleviate this risk by providing
-two ways for managing updates: migrations and store version updates.
+By default the persist API utilizes the mergeDeep strategy (you can read more
+about merge strategies further below). The mergeDeep strategy attempts to
+perform an optimistic merge of the persisted state against the store model.
+Where it finds that the persisted state is missing keys that are present in the
+store model, it will ensure to use the respective state from the store model. It
+will also verify the types of data at each key. If there is a misalignment
+(ignoring null or undefined) then it will opt for using the data from the store
+model instead as this generally indicates that the respective state has been
+refactored.
+
+Whilst the mergeDeep strategy is fairly robust and should be able to cater for a
+wide variety of model updates, it can't provide a 100% guarantee that a valid
+state structure will be resolved.
+
+Therefore, when dealing with production applications, we recommend that you
+consider removing this risk by using one of the two options described below:
 
 ### Migrations
 
@@ -328,28 +345,16 @@ persist(
 );
 ```
 
+Well-written migrations should obviate the need for merge strategies and render
+them no-ops. Note, however, that merge strategies are still applied and
+unexpected behavior may occur during rehydration as a result of non-exhaustive
+migrations.
+
 ### Forced updates via `version`
 
 If migrations are insufficient (which can often be the case after a major state
 refactor has taken place), the persist API also provides a means to "force
-update" the store via `version`.
-
-By default the persist API utilizes the `mergeDeep` strategy (you can read more
-above merge strategies further below). The `mergeDeep` strategy attempts to
-perform an optimistic merge of the persisted state against the store model.
-Where it finds that the persisted state is missing keys that are present in the
-store model, it will ensure to use the respective state from the store model. It
-will also verify the types of data at each key. If there is a misalignment
-(ignoring `null` or `undefined`) then it will opt for using the data from the
-store model instead as this generally indicates that the respective state has
-been refactored.
-
-Whilst the `mergeDeep` strategy is fairly robust and should be able to cater for
-a wide variety of model updates, it can't provide a 100% guarantee that a valid
-state structure will be resolved.
-
-Therefore, when dealing with production applications, we recommend that you
-consider removing this risk. You can do so by utilizing the `version`
+update" the store via version. You can do so by utilizing the `version`
 configuration property that is available on the store config.
 
 ```javascript


### PR DESCRIPTION
Similar to [`redux-persist`](https://github.com/rt2zz/redux-persist#migrations), this PR adds the ability to migrate persisted state using a new `migrations` option on the `persist` helper. It looks like this: 

```tsx
const memoryStorage = createMemoryStorage({
  '[EasyPeasyStore][0]': {
    foo: "foo-updated",
    migrationConfict: "error"
  },
});

const store = createStore(
  persist(
    {
      foo: {
        bar: "bar",
      },
      bar: "bar",
    },
    {
      storage: memoryStorage,
      migrations: {
        migrationVersion: 1,

        0: (state) => {
          state.foo = { bar: state.foo };
        },
        1: (state) => {
          delete state.migrationConfict;
        },
      },
    }
  )
);
```

Yielding this updated store representation:
```json
{ 
  "foo": { 
    "bar": "foo-updated" 
  }, 
  "bar": "bar", 
  "_migrationVersion": 1 
}
```

**How it works**: 
- Numeric object keys are added to the `migrations` object
- Each migration function is an immer draft updator, which takes state
- The migrator will look at the currently stored internal version (`state._migrationVersion`) and perform migrations up to `migrations.migrationVersion`, as defined in the store configuration setup. 

**Questions**:
1. We need to persist the currently migrated version, as that value is what's compared against for future migrations. Right now it's been added as `_migrationVersion` but perhaps there's a better place for this? 
2. Anything I might be missing in the implementation? It felt surprisingly straightforward. 