### PR TITLE
[Bugfix] persist not working on iOS

### DIFF
--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,3 +1,4 @@
+import timingMethod from './utils/timingMethod';
 import { clone, get, isPlainObject, isPromise, set, pSeries } from './lib';
 import { migrate } from './migrations';
 
@@ -76,7 +77,9 @@ function createStorageWrapper(storage, transformers = [], migrations = {}) {
         : data;
 
     const hasMigrations = Object.keys(migrations).length > 0;
-    const result = hasMigrations ? migrate(storageData, migrations) : storageData;
+    const result = hasMigrations
+      ? migrate(storageData, migrations)
+      : storageData;
 
     if (
       outTransformers.length > 0 &&
@@ -168,13 +171,6 @@ export function createPersistor(persistKey, _r) {
   let persistPromise = Promise.resolve();
   let isPersisting = false;
   let nextPersistOperation;
-
-  const timingMethod =
-    typeof window === 'undefined'
-      ? (fn) => fn()
-      : window.requestIdleCallback != null
-      ? window.requestIdleCallback
-      : window.requestAnimationFrame;
 
   const persist = (nextState) => {
     if (_r._i._persistenceConfig.length === 0) {

--- a/src/utils/timingMethod.ios.js
+++ b/src/utils/timingMethod.ios.js
@@ -1,0 +1,6 @@
+// requestIdleCallback is defined, but not invoked in iOS, so we use requestAnimationFrame instead
+// The RN bundler will import this file instead of timingMethod.js on iOS
+const timingMethod =
+  typeof window === 'undefined' ? (fn) => fn() : window.requestAnimationFrame;
+
+export default timingMethod;

--- a/src/utils/timingMethod.js
+++ b/src/utils/timingMethod.js
@@ -1,0 +1,9 @@
+// Note: requestIdleCallback is not available on iOS - see timingMethod.ios.js
+const timingMethod =
+  typeof window === 'undefined'
+    ? (fn) => fn()
+    : window.requestIdleCallback != null
+    ? window.requestIdleCallback
+    : window.requestAnimationFrame;
+
+export default timingMethod;

--- a/website/docs/docs/recipes/connecting-to-reactotron.md
+++ b/website/docs/docs/recipes/connecting-to-reactotron.md
@@ -30,12 +30,6 @@ Then update the manner in which you create your Easy Peasy store.
 import { createStore } from 'easy-peasy';
 import model from './model';
 
-// There might be an issue causing `setItem` not being called correctly
-// for iOS devices using React Native. The solution for this is currently
-// to remove the implemenation of `requestIdleCallback`.
-// Read this issue for more information: https://github.com/ctrlplusb/easy-peasy/issues/599
-window.requestIdleCallback = null;
-
 let storeEnhancers = [];
 
 if (__DEV__) {


### PR DESCRIPTION
`createPersistor` defines a `timingMethod` that won't work on iOS.

This is because this method utilizes `requestIdleCallback`, which is defined on iOS - but never invoked 🤯

So, for iOS we have to fallback to utilize `requestAnimationFrame`. This is done by vendoring a specific file `timingMethod.ios.js`, which the RN bundle can import for the iOS platform.