### PR TITLE
fix: set default error on empty helpers.fail() call.

### DIFF
--- a/src/thunks.js
+++ b/src/thunks.js
@@ -77,7 +77,7 @@ export function createThunkActionsCreator(def, _r) {
     let failure = null;
 
     const fail = (_failure) => {
-      failure = _failure;
+      failure = _failure || new Error();
     };
 
     const result = _r.dispatch(() => def.thunkHandler(payload, fail));

--- a/tests/listener-actions.test.js
+++ b/tests/listener-actions.test.js
@@ -121,6 +121,10 @@ it('listening to a successful or failed thunk, firing an action', async () => {
           helpers.fail('💩');
           return undefined;
         }
+        if (payload === 8) {
+          helpers.fail();
+          return undefined;
+        }
         return 'foo';
       }),
     },
@@ -162,6 +166,20 @@ it('listening to a successful or failed thunk, firing an action', async () => {
   expect(actualTarget.result).toBeUndefined();
   expect(actualTarget.error).toBe('💩');
   expect(store.getState().audit.logs).toEqual(['Added 10', 'Failed to add 7']);
+
+  // ACT
+  await store.getActions().math.add(8);
+
+  // ASSERT
+  expect(actualTarget.type).toBe('@thunk.math.add(fail)');
+  expect(actualTarget.payload).toBe(8);
+  expect(actualTarget.result).toBeUndefined();
+  expect(actualTarget.error).toStrictEqual(new Error());
+  expect(store.getState().audit.logs).toEqual([
+    'Added 10',
+    'Failed to add 7',
+    'Failed to add 8',
+  ]);
 });
 
 it('listening to a failed thunk', async () => {


### PR DESCRIPTION
## Issue

The current implementation of the `helpers.fail()` method triggers a thunk fail only when an error argument is provided. This behavior can be misleading given the documentation states:

*You may pass your error object or any arbitrary payload to fail.*

However, it does not explicitly mention that passing an error is compulsory.

## Proposed Solutions
Three potential ways to address this ambiguity include:

1. Documentation Update: Elaborate in the documentation that the thunk will NOT fail if the method is invoked without parameters.
2. TypeScript Change (Breaking Change): Modify the TypeScript definition of the fail method to require a parameter, ensuring users always provide one. This however wont affect the JS users.
3. Behavior Modification (This PR): Adjust the method to fail a thunk irrespective of parameter presence. In cases without a parameter, default the error value to an empty Error object. (Note: This might introduce unforeseen side-effects, for example users relying on a success thunk after having called an empty helpers.fail().)




