### PR TITLE
bugfix: Allow async effects for `effectOn`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -731,7 +731,7 @@ export function effectOn<
     actions: Actions<Model>,
     change: Change<Resolvers>,
     helpers: Helpers<Model, StoreModel, Injections>,
-  ) => undefined | void | Dispose,
+  ) => undefined | void | Dispose | Promise<Dispose>,
 ): EffectOn<Model, StoreModel, Injections>;
 
 // #endregion
@@ -1042,8 +1042,10 @@ export interface PersistConfig<Model extends object> {
   mergeStrategy?: 'mergeDeep' | 'mergeShallow' | 'overwrite';
   migrations?: {
     migrationVersion: number;
-    [key: number]: (state: Partial<Model & { [key: string | number]: any }>) => void;
-  }
+    [key: number]: (
+      state: Partial<Model & { [key: string | number]: any }>,
+    ) => void;
+  };
   storage?: 'localStorage' | 'sessionStorage' | PersistStorage;
   transformers?: Array<Transformer>;
 }

--- a/tests/typescript/effect-on.ts
+++ b/tests/typescript/effect-on.ts
@@ -9,6 +9,7 @@ interface TodosModel {
   foo: string;
   setFoo: Action<TodosModel, string>;
   onStateChanged: EffectOn<TodosModel, StoreModel, Injections>;
+  onStateChangedAsync: EffectOn<TodosModel, StoreModel, Injections>;
 }
 
 interface StoreModel {
@@ -49,6 +50,13 @@ const todosModel: TodosModel = {
       helpers.meta.parent[0].toLowerCase();
       helpers.meta.path[0].toLowerCase();
 
+      return () => console.log('dispose');
+    },
+  ),
+  onStateChangedAsync: effectOn(
+    [(state) => state.items],
+    // Should not generate error for async effect
+    async (actions, change, helpers) => {
       return () => console.log('dispose');
     },
   ),


### PR DESCRIPTION
The docs states that [async effects should be allowed in an `effectOn`](https://easy-peasy.dev/docs/api/effect-on.html#utilising-a-dispose-function).

This works in JS, but not in TS - due to the type definition.

Updates the type defs to allow for async effects.