### PR TITLE
fix: computed props w/ dependencies on store state

### DIFF
--- a/src/computed-properties.js
+++ b/src/computed-properties.js
@@ -1,8 +1,8 @@
 import equal from 'fast-deep-equal/es6';
 import { areInputsEqual } from './lib';
 
-export function createComputedPropertyBinder(parentPath, key, def, _r) {
-  let runOnce = false;
+export function createComputedPropertyBinder(key, def, _r) {
+  let hasRunOnce = false;
   let prevInputs = [];
   let prevValue;
   let prevStoreState;
@@ -28,10 +28,11 @@ export function createComputedPropertyBinder(parentPath, key, def, _r) {
         const inputs = def.stateResolvers.map((resolver) =>
           resolver(parentState, storeState),
         );
+
         if (
-          runOnce &&
-          (storeState === prevStoreState ||
-            areInputsEqual(inputs, prevInputs) ||
+          hasRunOnce &&
+          ((storeState === prevStoreState &&
+            areInputsEqual(inputs, prevInputs)) ||
             // We don't want computed properties resolved every time an action
             // is handled by the reducer. They need to remain lazy, only being
             // computed when used by a component or getState call;
@@ -49,7 +50,7 @@ export function createComputedPropertyBinder(parentPath, key, def, _r) {
 
         prevInputs = inputs;
         prevStoreState = storeState;
-        runOnce = true;
+        hasRunOnce = true;
         return prevValue;
       },
     });

--- a/src/extract-data-from-model.js
+++ b/src/extract-data-from-model.js
@@ -150,7 +150,6 @@ export default function extractDataFromModel(
         } else if (value[computedSymbol]) {
           const parent = get(parentPath, _dS);
           const bindComputedProperty = createComputedPropertyBinder(
-            parentPath,
             key,
             value,
             _r,
@@ -158,7 +157,12 @@ export default function extractDataFromModel(
           bindComputedProperty(parent, _dS);
           _cP.push({ key, parentPath, bindComputedProperty });
         } else if (value[reducerSymbol]) {
-          _cR.push({ key, parentPath, reducer: value.fn, config: value.config });
+          _cR.push({
+            key,
+            parentPath,
+            reducer: value.fn,
+            config: value.config,
+          });
         } else if (value[effectOnSymbol]) {
           const def = { ...value };
 


### PR DESCRIPTION
- Changes `storeState === prevStoreState || areInputsEqual(...)` to `storeState === prevStoreState && areInputsEqual(...)` when considering whether or not to return the cached value of a computed prop. Only if both conditions are true should we blindly return the cached value. If either condition is false, we should re-calculate and find out if the value has changed. If it has not, return the cached value still (this may happen if inputs are equal and store state has changed that the computed prop does not depend on). Otherwise update cached value and trigger re-render.
- I believe this is related to the changes introduced in #764. This PR optimized computed props to reduce/remove the number of unwanted re-renders, however the optimization was maybe a bit too aggressive and missed a few edge cases where it doesn't trigger a re-render when it should.
- The new test fails prior to this code change and illustrates the issue that prompted the filing of #873.
- This PR also removes an un-used argument from the `createComputedPropertyBinder` and changes the `runOnce` variable name to `hasRunOnce` (just for a little more clarity - this always confused be a bit at first).
 
fixes #873 