### PR TITLE
Making sure models created with useLocalStore stop updating the state on update

### DIFF
--- a/src/use-local-store.js
+++ b/src/use-local-store.js
@@ -28,7 +28,7 @@ export function useLocalStore(
 
   useEffect(() => {
     setCurrentState(store.getState());
-    store.subscribe(() => {
+    return store.subscribe(() => {
       const nextState = store.getState();
       if (currentState !== nextState) {
         setCurrentState(nextState);


### PR DESCRIPTION
As described in https://github.com/ctrlplusb/easy-peasy/issues/913, when a model created by `useLocalStore` is re-created due to dependency array change, it won't unsubscribe itself and will continue delivering state updates to (now new) model.

The test case added in this PR demonstrates exactly that (fails on current `master`, works in this branch).