### PR TITLE
Change default export with named export

### DIFF
--- a/website/docs/docs/typescript-api/create-typed-hooks.md
+++ b/website/docs/docs/typescript-api/create-typed-hooks.md
@@ -11,7 +11,7 @@ import { StoreModel } from './model';
 
 const { useStoreActions, useStoreState, useStoreDispatch, useStore } = createTypedHooks<StoreModel>();
 
-export default {
+export {
   useStoreActions,
   useStoreState,
   useStoreDispatch,


### PR DESCRIPTION
By exporting each hook in a default object doesn't allow to import them individually as shown down on the sample of how to use them.

It's very confusing for the users reading the docs.

Error displayed by ESLint:
![image](https://github.com/user-attachments/assets/529d8ff3-8f46-4c82-b418-35db42fc047c)

Alternative way of importing the typed hooks (not ideal):
![image](https://github.com/user-attachments/assets/2bfeb8de-eb0a-4677-aec7-77a0d3197bed)

Ideal way of importing the typed hooks:
![image](https://github.com/user-attachments/assets/e0bc27bc-dd51-498d-ad63-c55d3e30c546)
