### PR TITLE
feat(hooks): add useStoreTransition and useStoreDeferredState

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -918,6 +918,59 @@ export function useStoreDispatch<
 >(): Dispatch<StoreModel>;
 
 /**
+ * A React Hook that wraps action dispatches in `startTransition`, marking the
+ * resulting state updates as non-urgent so they do not block higher-priority
+ * updates such as user input.
+ *
+ * Returns a tuple of `[wrappedActions, isPending]`. `wrappedActions` mirrors
+ * the shape returned by the `mapActions` selector — function leaves are
+ * wrapped to dispatch within `startTransition`.
+ *
+ * Note: you can create a pre-typed version of this hook via "createTypedHooks"
+ *
+ * @example
+ *
+ * import { useStoreTransition, Actions } from 'easy-peasy';
+ *
+ * function MyComponent() {
+ *   const [addTodo, isPending] = useStoreTransition(
+ *     (actions: Actions<StoreModel>) => actions.todos.add,
+ *   );
+ *   return <AddTodoForm save={addTodo} pending={isPending} />;
+ * }
+ */
+export function useStoreTransition<
+  StoreActions extends Actions<any> = Actions<{}>,
+  Result = any,
+>(mapActions: (actions: StoreActions) => Result): [Result, boolean];
+
+/**
+ * A React Hook that combines `useStoreState` with `useDeferredValue`, allowing
+ * React to keep returning the previous selected value while a new value is
+ * being computed for an expensive selector.
+ *
+ * Note: you can create a pre-typed version of this hook via "createTypedHooks"
+ *
+ * @example
+ *
+ * import { useStoreDeferredState, State } from 'easy-peasy';
+ *
+ * function MyComponent() {
+ *   const results = useStoreDeferredState(
+ *     (state: State<StoreModel>) => expensiveSelect(state),
+ *   );
+ *   return <Results items={results} />;
+ * }
+ */
+export function useStoreDeferredState<
+  StoreState extends State<any> = State<{}>,
+  Result = any,
+>(
+  mapState: (state: StoreState) => Result,
+  equalityFn?: (prev: Result, next: Result) => boolean,
+): Result;
+
+/**
  * A utility function used to create pre-typed hooks.
  *
  * https://easypeasy.now.sh/docs/api/create-typed-hooks.html
@@ -939,6 +992,13 @@ export function createTypedHooks<StoreModel extends object = {}>(): {
     equalityFn?: (prev: Result, next: Result) => boolean,
   ) => Result;
   useStore: () => Store<StoreModel>;
+  useStoreTransition: <Result>(
+    mapActions: (actions: Actions<StoreModel>) => Result,
+  ) => [Result, boolean];
+  useStoreDeferredState: <Result>(
+    mapState: (state: State<StoreModel>) => Result,
+    equalityFn?: (prev: Result, next: Result) => boolean,
+  ) => Result;
 };
 
 // #endregion
@@ -1004,6 +1064,13 @@ export function createContextStore<
   ) => Result;
   useStoreDispatch: () => Dispatch<StoreModel>;
   useStoreRehydrated: () => boolean;
+  useStoreTransition: <Result = any>(
+    mapActions: (actions: Actions<StoreModel>) => Result,
+  ) => [Result, boolean];
+  useStoreDeferredState: <Result = any>(
+    mapState: (state: State<StoreModel>) => Result,
+    equalityFn?: (prev: Result, next: Result) => boolean,
+  ) => Result;
 };
 
 export function useLocalStore<

--- a/src/create-context-store.js
+++ b/src/create-context-store.js
@@ -3,9 +3,11 @@
 import React, { createContext, useContext } from 'react';
 import {
   createStoreActionsHook,
+  createStoreDeferredStateHook,
   createStoreDispatchHook,
   createStoreStateHook,
   createStoreRehydratedHook,
+  createStoreTransitionHook,
 } from './hooks';
 import { createStore } from './create-store';
 import { useMemoOne } from './lib';
@@ -58,5 +60,7 @@ export function createContextStore(model, config = {}) {
     useStoreActions: createStoreActionsHook(StoreContext),
     useStoreDispatch: createStoreDispatchHook(StoreContext),
     useStoreRehydrated: createStoreRehydratedHook(StoreContext),
+    useStoreTransition: createStoreTransitionHook(StoreContext),
+    useStoreDeferredState: createStoreDeferredStateHook(StoreContext),
   };
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,11 +1,13 @@
 import {
   useContext,
   useDebugValue,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
   useState,
   useSyncExternalStore,
+  useTransition,
 } from 'react';
 import EasyPeasyContext from './context';
 
@@ -136,6 +138,52 @@ export function createStoreActionsHook(Context) {
 
 export const useStoreActions = createStoreActionsHook(EasyPeasyContext);
 
+function wrapInTransition(target, startTransition) {
+  if (typeof target === 'function') {
+    return (...args) => {
+      let result;
+      startTransition(() => {
+        result = target(...args);
+      });
+      return result;
+    };
+  }
+  if (target !== null && typeof target === 'object') {
+    const wrapped = {};
+    for (const key of Object.keys(target)) {
+      wrapped[key] = wrapInTransition(target[key], startTransition);
+    }
+    return wrapped;
+  }
+  return target;
+}
+
+export function createStoreTransitionHook(Context) {
+  return function useStoreTransition(mapActions) {
+    const store = useContext(Context);
+    const [isPending, startTransition] = useTransition();
+    const actions = mapActions(store.getActions());
+    const wrappedActions = useMemo(
+      () => wrapInTransition(actions, startTransition),
+      [actions, startTransition],
+    );
+    return [wrappedActions, isPending];
+  };
+}
+
+export const useStoreTransition = createStoreTransitionHook(EasyPeasyContext);
+
+export function createStoreDeferredStateHook(Context) {
+  const useStoreStateForContext = createStoreStateHook(Context);
+  return function useStoreDeferredState(mapState, equalityFn) {
+    const value = useStoreStateForContext(mapState, equalityFn);
+    return useDeferredValue(value);
+  };
+}
+
+export const useStoreDeferredState =
+  createStoreDeferredStateHook(EasyPeasyContext);
+
 export function createStoreDispatchHook(Context) {
   return function useStoreDispatch() {
     const store = useContext(Context);
@@ -169,5 +217,7 @@ export function createTypedHooks() {
     useStoreState,
     useStoreRehydrated,
     useStore,
+    useStoreTransition,
+    useStoreDeferredState,
   };
 }

--- a/tests/use-store-deferred-state.test.js
+++ b/tests/use-store-deferred-state.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
+import {
+  action,
+  createStore,
+  StoreProvider,
+  useStoreActions,
+  useStoreDeferredState,
+} from '../src';
+
+test('returns the current state on initial render', () => {
+  // ARRANGE
+  const store = createStore({
+    name: 'Alice',
+  });
+
+  function App() {
+    const name = useStoreDeferredState((s) => s.name);
+    return <div data-testid="name">{name}</div>;
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  // ASSERT
+  expect(getByTestId('name').textContent).toBe('Alice');
+});
+
+test('updates after a dispatched action', () => {
+  // ARRANGE
+  const store = createStore({
+    name: 'Alice',
+    setName: action((state, payload) => {
+      state.name = payload;
+    }),
+  });
+
+  function App() {
+    const name = useStoreDeferredState((s) => s.name);
+    const setName = useStoreActions((a) => a.setName);
+    return (
+      <>
+        <div data-testid="name">{name}</div>
+        <button data-testid="rename" onClick={() => setName('Bob')} type="button">
+          rename
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  // ACT
+  act(() => {
+    fireEvent.click(getByTestId('rename'));
+  });
+
+  // ASSERT
+  expect(getByTestId('name').textContent).toBe('Bob');
+});
+
+test('respects the equality function to avoid spurious updates', () => {
+  // ARRANGE
+  const renderSpy = vi.fn();
+
+  const store = createStore({
+    user: { id: 1, name: 'Alice' },
+    rename: action((state, payload) => {
+      state.user = { ...state.user, name: payload };
+    }),
+  });
+
+  function App() {
+    const user = useStoreDeferredState(
+      (s) => s.user,
+      (prev, next) => prev.id === next.id,
+    );
+    const rename = useStoreActions((a) => a.rename);
+    renderSpy(user.name);
+    return (
+      <>
+        <div data-testid="name">{user.name}</div>
+        <button data-testid="rename" onClick={() => rename('Bob')} type="button">
+          rename
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(renderSpy).toHaveBeenLastCalledWith('Alice');
+
+  // ACT
+  act(() => {
+    fireEvent.click(getByTestId('rename'));
+  });
+
+  // ASSERT — equality fn collapses to same id, so deferred value stays Alice
+  expect(getByTestId('name').textContent).toBe('Alice');
+});

--- a/tests/use-store-transition.test.js
+++ b/tests/use-store-transition.test.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
+import {
+  action,
+  createStore,
+  StoreProvider,
+  useStoreState,
+  useStoreTransition,
+  thunk,
+} from '../src';
+
+test('wraps a single action and exposes isPending', () => {
+  // ARRANGE
+  const store = createStore({
+    count: 0,
+    increment: action((state) => {
+      state.count += 1;
+    }),
+  });
+
+  function App() {
+    const count = useStoreState((s) => s.count);
+    const [increment, isPending] = useStoreTransition((a) => a.increment);
+    return (
+      <>
+        <div data-testid="count">{count}</div>
+        <div data-testid="pending">{isPending ? 'yes' : 'no'}</div>
+        <button data-testid="bump" onClick={() => increment()} type="button">
+          bump
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  // ASSERT
+  expect(getByTestId('count').textContent).toBe('0');
+  expect(getByTestId('pending').textContent).toBe('no');
+
+  // ACT
+  act(() => {
+    fireEvent.click(getByTestId('bump'));
+  });
+
+  // ASSERT
+  expect(getByTestId('count').textContent).toBe('1');
+});
+
+test('recursively wraps function leaves of an object selector', () => {
+  // ARRANGE
+  const store = createStore({
+    todos: {
+      items: [],
+      add: action((state, payload) => {
+        state.items.push(payload);
+      }),
+      clear: action((state) => {
+        state.items = [];
+      }),
+    },
+  });
+
+  function App() {
+    const items = useStoreState((s) => s.todos.items);
+    const [todos] = useStoreTransition((a) => a.todos);
+    return (
+      <>
+        <div data-testid="items">{items.join(',')}</div>
+        <button
+          data-testid="add"
+          onClick={() => todos.add('write tests')}
+          type="button"
+        >
+          add
+        </button>
+        <button data-testid="clear" onClick={() => todos.clear()} type="button">
+          clear
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  // ACT
+  act(() => {
+    fireEvent.click(getByTestId('add'));
+  });
+
+  // ASSERT
+  expect(getByTestId('items').textContent).toBe('write tests');
+
+  // ACT
+  act(() => {
+    fireEvent.click(getByTestId('clear'));
+  });
+
+  // ASSERT
+  expect(getByTestId('items').textContent).toBe('');
+});
+
+test('wrapped thunks return their original promise', async () => {
+  // ARRANGE
+  const store = createStore({
+    items: [],
+    addItem: action((state, payload) => {
+      state.items.push(payload);
+    }),
+    fetchItem: thunk(async (actions, payload) => {
+      actions.addItem(payload);
+      return `done:${payload}`;
+    }),
+  });
+
+  let captured;
+
+  function App() {
+    const [fetchItem] = useStoreTransition((a) => a.fetchItem);
+    return (
+      <button
+        data-testid="fetch"
+        onClick={() => {
+          captured = fetchItem('one');
+        }}
+        type="button"
+      >
+        fetch
+      </button>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  // ACT
+  await act(async () => {
+    fireEvent.click(getByTestId('fetch'));
+  });
+
+  // ASSERT
+  await expect(captured).resolves.toBe('done:one');
+  expect(store.getState().items).toEqual(['one']);
+});


### PR DESCRIPTION
## Summary

Adds two new opt-in hooks leveraging React 18 concurrent rendering primitives. Both are additive — no changes to existing hook behavior.

Closes #1016. Part of the v7 work tracked under #1004 / #1020.

## Changes

### `useStoreTransition(mapActions)` — returns `[wrappedActions, isPending]`

Wraps action dispatches in `startTransition` so resulting state updates are non-urgent and don't block higher-priority work (e.g. user input). Best fit: thunks that issue multiple incremental updates (loading → data → complete).

- If `mapActions` returns a function, the function is wrapped to dispatch within `startTransition`.
- If it returns an object, function leaves are recursively wrapped — matches the flexibility of `useStoreActions`.
- `isPending` reflects React's transition state.

```js
const [addTodo, isPending] = useStoreTransition((a) => a.todos.add);
const [todos] = useStoreTransition((a) => a.todos); // { add, remove } both wrapped
```

### `useStoreDeferredState(selector, equalityFn?)`

Mirrors `useStoreState` but routes the selected value through `useDeferredValue`, letting React keep the previous value while a new one is being computed for an expensive selector.

```js
const results = useStoreDeferredState((s) => expensiveSelect(s));
```

### Plumbing

- Factory creators `createStoreTransitionHook(Context)` and `createStoreDeferredStateHook(Context)` for custom Context support, matching the existing pattern.
- Both added to `createTypedHooks()` and `createContextStore()` returns.
- TypeScript definitions added to `index.d.ts`.

## Tests

- `tests/use-store-transition.test.js` — single action wrapping, recursive object wrapping, thunk return-value preservation.
- `tests/use-store-deferred-state.test.js` — initial render, post-dispatch update, equality-fn collapsing.

All 184 existing tests still pass; lint and dtslint clean; build emits correct dist with `'use client'` banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)