### PR TITLE
feat(persist): wrap rehydration replaceState in startTransition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
+import { startTransition } from 'react';
+import { setTransitionFn } from './transitions';
+
+setTransitionFn(startTransition);
+
 export * from './hooks';
 export * from './create-store';
 export * from './create-context-store';

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,5 +1,6 @@
 import { clone, get, isPlainObject, isPromise, set, pSeries } from './lib';
 import { migrate } from './migrations';
+import { runWithTransition } from './transitions';
 
 const noopStorage = {
   getItem: () => undefined,
@@ -339,7 +340,7 @@ export function rehydrateStateFromPersistIfNeeded(
     }),
   ).then(() => {
     if (rehydrating) {
-      replaceState(state);
+      runWithTransition(() => replaceState(state));
     }
   });
 }

--- a/src/transitions.js
+++ b/src/transitions.js
@@ -1,0 +1,9 @@
+let transitionFn = (callback) => callback();
+
+export function setTransitionFn(fn) {
+  transitionFn = typeof fn === 'function' ? fn : (callback) => callback();
+}
+
+export function runWithTransition(callback) {
+  transitionFn(callback);
+}

--- a/tests/rehydration-transition.test.js
+++ b/tests/rehydration-transition.test.js
@@ -1,0 +1,106 @@
+import { vi } from 'vitest';
+import { action, createStore, persist } from '../src';
+import { setTransitionFn } from '../src/transitions';
+
+const wait = (time = 18) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+
+const createMemoryStorage = (
+  initial = {},
+  config = { async: false, asyncTime: 18 },
+) => {
+  const store = initial;
+  const { async, asyncTime } = config;
+  return {
+    setItem: (key, data) => {
+      if (async) {
+        return wait(asyncTime).then(() => {
+          store[key] = data;
+        });
+      }
+      store[key] = data;
+      return undefined;
+    },
+    getItem: (key) => {
+      const data = store[key];
+      return async ? wait(asyncTime).then(() => data) : data;
+    },
+    removeItem: (key) => {
+      if (async) {
+        return wait(asyncTime).then(() => {
+          delete store[key];
+        });
+      }
+      delete store[key];
+      return undefined;
+    },
+    store,
+  };
+};
+
+const makeModel = () => ({
+  counter: 0,
+  change: action((_, payload) => payload),
+});
+
+afterEach(async () => {
+  const { startTransition } = await import('react');
+  setTransitionFn(startTransition);
+});
+
+test('rehydration replaceState is wrapped in startTransition', async () => {
+  const memoryStorage = createMemoryStorage();
+  const transitionSpy = vi.fn((callback) => callback());
+  setTransitionFn(transitionSpy);
+
+  const initial = createStore(persist(makeModel(), { storage: memoryStorage }));
+  initial.getActions().change({ counter: 7 });
+  await initial.persist.flush();
+
+  expect(transitionSpy).not.toHaveBeenCalled();
+
+  const rehydrated = createStore(
+    persist(makeModel(), { storage: memoryStorage }),
+  );
+  await rehydrated.persist.resolveRehydration();
+
+  expect(transitionSpy).toHaveBeenCalledTimes(1);
+  expect(rehydrated.getState()).toEqual({ counter: 7 });
+});
+
+test('startTransition wrapping does not break rehydration ordering or values', async () => {
+  const memoryStorage = createMemoryStorage(
+    {},
+    { async: true, asyncTime: 5 },
+  );
+  const transitionSpy = vi.fn((callback) => callback());
+  setTransitionFn(transitionSpy);
+
+  const initial = createStore(persist(makeModel(), { storage: memoryStorage }));
+  initial.getActions().change({ counter: 42 });
+  await initial.persist.flush();
+
+  const rehydrated = createStore(
+    persist(makeModel(), { storage: memoryStorage }),
+  );
+
+  expect(rehydrated.getState()).toEqual({ counter: 0 });
+
+  await rehydrated.persist.resolveRehydration();
+
+  expect(rehydrated.getState()).toEqual({ counter: 42 });
+  expect(transitionSpy).toHaveBeenCalledTimes(1);
+});
+
+test('startTransition is not invoked when no persisted state exists', async () => {
+  const memoryStorage = createMemoryStorage();
+  const transitionSpy = vi.fn((callback) => callback());
+  setTransitionFn(transitionSpy);
+
+  const store = createStore(persist(makeModel(), { storage: memoryStorage }));
+  await store.persist.resolveRehydration();
+
+  expect(transitionSpy).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

- Wrap the post-rehydration `replaceState` dispatch in `React.startTransition` so the resulting render is non-blocking — useful when rehydration swaps a large amount of state in one shot.
- Wrapper installation lives in a dedicated `src/transitions.js` module with a no-op default; `src/index.js` installs `React.startTransition` as a side-effect import. The `easy-peasy/server` entry never imports it, so the React-free server bundle delivered in #1023 stays React-free.
- Addresses the React 18 compatible portion of #1015. The `use()` hook portion remains deferred pending the React-version strategy decision.

## Changes

- `src/transitions.js` (new) — `setTransitionFn` / `runWithTransition` with a no-op default.
- `src/index.js` — installs `React.startTransition` via `setTransitionFn` on module load.
- `src/persistence.js` — wraps the rehydration `replaceState(state)` call in `runWithTransition`.
- `tests/rehydration-transition.test.js` (new) — verifies `startTransition` is invoked exactly once on rehydration when persisted state exists, that rehydrated state values still arrive correctly, and that no transition is triggered when there is nothing to rehydrate.

## Verification

- `yarn build` — `dist/server.js` and `dist/server.cjs.js` contain zero React references; `dist/index.js` includes `setTransitionFn(startTransition)` at module load.
- `yarn test` — 190 passed + 1 todo (was 187 + 1 todo; +3 new tests).
- `yarn lint` — 0 errors, 2 pre-existing warnings (unchanged).
- `yarn dtslint` — clean.

Closes part of #1015 (`startTransition` for rehydration). The `use()` hook follow-up stays open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)