### PR TITLE
feat(react)!: drop React 18 support, require React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
     "@types/react": "^19.0.8"
   },
   "peerDependencies": {
-    "@types/react": "^18.0 || ^19.0",
-    "@types/react-dom": "^18.0 || ^19.0",
-    "react": "^18.0 || ^19.0",
-    "react-dom": "^18.0 || ^19.0",
+    "@types/react": "^19.0",
+    "@types/react-dom": "^19.0",
+    "react": "^19.0",
+    "react-dom": "^19.0",
     "react-native": ">=0.59"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

Bumps minimum peer dependency for `react` and `react-dom` from `^18.0 || ^19.0` to `^19.0`. Drops React 18 support.

Part of v7 work tracked under #1020 / #1004. Unblocks adoption of React 19 primitives (`use()`, `useOptimistic`, `useActionState`) without version-gating shims, runtime feature detection, or split exports.

## Changes

- \`package.json\` peer deps: \`react\`, \`react-dom\`, \`@types/react\`, \`@types/react-dom\` all narrowed to \`^19.0\`.

No source changes — there were no React-18 compat shims in source to remove. Dev dependencies were already pinned to React 19, so the lockfile is unchanged.

## Breaking change

Consumers on React 18 must upgrade to React 19 before adopting easy-peasy v7.