### PR TITLE
feat(hooks): add useStoreOptimistic for optimistic UI updates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -971,6 +971,38 @@ export function useStoreDeferredState<
 ): Result;
 
 /**
+ * A React Hook that combines `useStoreState` with `useOptimistic`, allowing
+ * components to optimistically update derived state during a pending action.
+ *
+ * Returns a tuple of `[optimisticState, addOptimistic]`. The optimistic value
+ * is shown until the underlying store state next changes (typically when the
+ * pending action completes), at which point it resets to reflect the real
+ * store value.
+ *
+ * Note: you can create a pre-typed version of this hook via "createTypedHooks"
+ *
+ * @example
+ *
+ * import { useStoreOptimistic, State } from 'easy-peasy';
+ *
+ * function MyComponent() {
+ *   const [items, addOptimistic] = useStoreOptimistic(
+ *     (state: State<StoreModel>) => state.todos.items,
+ *     (current, pending: Todo) => [...current, pending],
+ *   );
+ *   return <TodoList items={items} onAdd={addOptimistic} />;
+ * }
+ */
+export function useStoreOptimistic<
+  StoreState extends State<any> = State<{}>,
+  Result = any,
+  Optimistic = Result,
+>(
+  mapState: (state: StoreState) => Result,
+  updateFn: (current: Result, optimisticValue: Optimistic) => Result,
+): [Result, (optimisticValue: Optimistic) => void];
+
+/**
  * A utility function used to create pre-typed hooks.
  *
  * https://easypeasy.now.sh/docs/api/create-typed-hooks.html
@@ -999,6 +1031,10 @@ export function createTypedHooks<StoreModel extends object = {}>(): {
     mapState: (state: State<StoreModel>) => Result,
     equalityFn?: (prev: Result, next: Result) => boolean,
   ) => Result;
+  useStoreOptimistic: <Result, Optimistic = Result>(
+    mapState: (state: State<StoreModel>) => Result,
+    updateFn: (current: Result, optimisticValue: Optimistic) => Result,
+  ) => [Result, (optimisticValue: Optimistic) => void];
 };
 
 // #endregion
@@ -1071,6 +1107,10 @@ export function createContextStore<
     mapState: (state: State<StoreModel>) => Result,
     equalityFn?: (prev: Result, next: Result) => boolean,
   ) => Result;
+  useStoreOptimistic: <Result = any, Optimistic = Result>(
+    mapState: (state: State<StoreModel>) => Result,
+    updateFn: (current: Result, optimisticValue: Optimistic) => Result,
+  ) => [Result, (optimisticValue: Optimistic) => void];
 };
 
 export function useLocalStore<

--- a/src/create-context-store.js
+++ b/src/create-context-store.js
@@ -5,6 +5,7 @@ import {
   createStoreActionsHook,
   createStoreDeferredStateHook,
   createStoreDispatchHook,
+  createStoreOptimisticHook,
   createStoreStateHook,
   createStoreRehydratedHook,
   createStoreTransitionHook,
@@ -62,5 +63,6 @@ export function createContextStore(model, config = {}) {
     useStoreRehydrated: createStoreRehydratedHook(StoreContext),
     useStoreTransition: createStoreTransitionHook(StoreContext),
     useStoreDeferredState: createStoreDeferredStateHook(StoreContext),
+    useStoreOptimistic: createStoreOptimisticHook(StoreContext),
   };
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -5,6 +5,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useOptimistic,
   useRef,
   useSyncExternalStore,
   useTransition,
@@ -184,6 +185,17 @@ export function createStoreDeferredStateHook(Context) {
 export const useStoreDeferredState =
   createStoreDeferredStateHook(EasyPeasyContext);
 
+export function createStoreOptimisticHook(Context) {
+  const useStoreStateForContext = createStoreStateHook(Context);
+  return function useStoreOptimistic(mapState, updateFn) {
+    const value = useStoreStateForContext(mapState);
+    return useOptimistic(value, updateFn);
+  };
+}
+
+export const useStoreOptimistic =
+  createStoreOptimisticHook(EasyPeasyContext);
+
 export function createStoreDispatchHook(Context) {
   return function useStoreDispatch() {
     const store = useContext(Context);
@@ -216,5 +228,6 @@ export function createTypedHooks() {
     useStore,
     useStoreTransition,
     useStoreDeferredState,
+    useStoreOptimistic,
   };
 }

--- a/tests/use-store-optimistic.test.js
+++ b/tests/use-store-optimistic.test.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
+import {
+  action,
+  createStore,
+  StoreProvider,
+  thunk,
+  useStoreActions,
+  useStoreOptimistic,
+} from '../src';
+
+test('returns the current state on initial render', () => {
+  const store = createStore({
+    items: ['a'],
+  });
+
+  function App() {
+    const [items] = useStoreOptimistic(
+      (s) => s.items,
+      (current, pending) => [...current, pending],
+    );
+    return <div data-testid="items">{items.join(',')}</div>;
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(getByTestId('items').textContent).toBe('a');
+});
+
+test('reflects store updates from dispatched actions', () => {
+  const store = createStore({
+    items: ['a'],
+    addItem: action((state, payload) => {
+      state.items.push(payload);
+    }),
+  });
+
+  function App() {
+    const [items] = useStoreOptimistic(
+      (s) => s.items,
+      (current, pending) => [...current, pending],
+    );
+    const addItem = useStoreActions((a) => a.addItem);
+    return (
+      <>
+        <div data-testid="items">{items.join(',')}</div>
+        <button data-testid="add" onClick={() => addItem('b')} type="button">
+          add
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(getByTestId('items').textContent).toBe('a');
+
+  act(() => {
+    fireEvent.click(getByTestId('add'));
+  });
+
+  expect(getByTestId('items').textContent).toBe('a,b');
+});
+
+test('shows optimistic value during a pending async transition', async () => {
+  let resolveThunk;
+  const store = createStore({
+    items: ['a'],
+    addItem: action((state, payload) => {
+      state.items.push(payload);
+    }),
+    addItemAsync: thunk(async (actions, payload) => {
+      await new Promise((resolve) => {
+        resolveThunk = resolve;
+      });
+      actions.addItem(payload);
+    }),
+  });
+
+  function App() {
+    const [items, addOptimistic] = useStoreOptimistic(
+      (s) => s.items,
+      (current, pending) => [...current, `${pending}-pending`],
+    );
+    const addItemAsync = useStoreActions((a) => a.addItemAsync);
+    return (
+      <>
+        <div data-testid="items">{items.join(',')}</div>
+        <button
+          data-testid="add"
+          onClick={() => {
+            React.startTransition(async () => {
+              addOptimistic('b');
+              await addItemAsync('b');
+            });
+          }}
+          type="button"
+        >
+          add
+        </button>
+      </>
+    );
+  }
+
+  const { getByTestId } = render(
+    <StoreProvider store={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(getByTestId('items').textContent).toBe('a');
+
+  await act(async () => {
+    fireEvent.click(getByTestId('add'));
+  });
+
+  expect(getByTestId('items').textContent).toBe('a,b-pending');
+
+  await act(async () => {
+    resolveThunk();
+  });
+
+  expect(getByTestId('items').textContent).toBe('a,b');
+});


### PR DESCRIPTION
## Summary

Adds an opt-in hook composing `useStoreState` with React 19's `useOptimistic`. Returns `[optimisticState, addOptimistic]` — the optimistic value is shown until the underlying store state next changes (typically when the pending action settles), at which point it resets to the real store value.

Closes the `useOptimistic` portion of #1017. The `useActionState` portion remains as documentation work tracked under #1027.

## Usage

```jsx
function TodoList() {
  const [items, addOptimistic] = useStoreOptimistic(
    (state) => state.todos.items,
    (current, pending) => [...current, { ...pending, pending: true }],
  );
  const submitTodo = useStoreActions((a) => a.todos.submit);

  async function handleSubmit(formData) {
    React.startTransition(async () => {
      addOptimistic({ id: tempId(), text: formData.get('text') });
      await submitTodo(formData);
    });
  }

  return <List items={items} onSubmit={handleSubmit} />;
}
```

## Implementation

The hook is intentionally thin — it delegates to React's `useOptimistic` directly:

```js
export function createStoreOptimisticHook(Context) {
  const useStoreStateForContext = createStoreStateHook(Context);
  return function useStoreOptimistic(mapState, updateFn) {
    const value = useStoreStateForContext(mapState);
    return useOptimistic(value, updateFn);
  };
}
```

When the underlying state changes (the awaited action commits to the store), `useOptimistic` resets to the new value automatically — no extra wiring needed.

## Plumbing

- Factory creator `createStoreOptimisticHook(Context)` for custom Context support, matching the existing pattern.
- Added to `createTypedHooks()` and `createContextStore()` returns.
- TypeScript definitions added to `index.d.ts`.

## Tests

`tests/use-store-optimistic.test.js`:
- Returns the current state on initial render
- Reflects store updates from dispatched actions
- Shows optimistic value during a pending async transition (using `startTransition` + an async thunk gated on a manual resolver), then resets to the real state when the thunk completes

## Verification

- 193 tests pass + 1 todo (was 190 + 1; +3 new)
- Lint clean (1 pre-existing warning, unrelated)
- dtslint clean
- Build clean