### PR TITLE
chore(tests): import act from react instead of deprecated react-dom/test-utils

### DIFF
--- a/tests/use-store-deferred-state.test.js
+++ b/tests/use-store-deferred-state.test.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import {
   action,

--- a/tests/use-store-optimistic.test.js
+++ b/tests/use-store-optimistic.test.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import {
   action,

--- a/tests/use-store-state.test.js
+++ b/tests/use-store-state.test.js
@@ -1,7 +1,6 @@
  
 
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import shallowEqual from 'shallowequal';
 import { mockConsole } from './utils';

--- a/tests/use-store-transition.test.js
+++ b/tests/use-store-transition.test.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import {
   action,


### PR DESCRIPTION
## Summary

React 19 deprecated importing `act` from `react-dom/test-utils`; the canonical import is now `react`. Switch the four affected test files to fold `act` into the existing default-import line.

Surfaced by the v7 readiness audit. Test runs already emitted React's deprecation warnings on these files.

## Files

- `tests/use-store-state.test.js`
- `tests/use-store-deferred-state.test.js` (added in #1022)
- `tests/use-store-transition.test.js` (added in #1022)
- `tests/use-store-optimistic.test.js` (added in #1028)

Each line `import { act } from 'react-dom/test-utils'` was folded into the existing `import React from 'react'` as `import React, { act } from 'react'`.

## Verification

- 193 tests pass + 1 todo
- No more `ReactDOMTestUtils.act` deprecation warnings in test output
- Lint clean (1 pre-existing unrelated warning)