### PR TITLE
fix(tests): make useStoreRehydrated suspense test deterministic

### DIFF
--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -933,7 +933,15 @@ test('multiple stores', async () => {
 
 test('useStoreRehydrated', async () => {
   // ARRANGE
-  const memoryStorage = createMemoryStorage(undefined, { async: true });
+  let releaseGetItem;
+  const getItemPromise = new Promise((resolve) => {
+    releaseGetItem = resolve;
+  });
+  const memoryStorage = {
+    getItem: () => getItemPromise,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  };
   const store = sharedMakeStore({
     storage: memoryStorage,
   });
@@ -966,6 +974,7 @@ test('useStoreRehydrated', async () => {
 
   // ACT
   await act(async () => {
+    releaseGetItem(undefined);
     await store.persist.resolveRehydration();
   });
 


### PR DESCRIPTION
## Summary

The `useStoreRehydrated` test in \`tests/persist.test.js\` is flaky under
coverage instrumentation in CI — it failed on the v7 release PR (#1031).

The test relied on a setTimeout-based async memory storage (18ms) to keep
the rehydration promise pending while asserting the Suspense fallback.
Under coverage instrumentation the timer can fire inside the surrounding
\`act()\` block, so React unsuspends and the \`Loading...\` assertion fails
with \`expected null not to be null\`.

## Changes

- \`tests/persist.test.js\` — replace the timer-based async storage with a
  manually-controlled deferred promise. The rehydration gate is held until
  the test explicitly releases it, removing the timing race.