### PR TITLE
chore(release): bump version to 7.0.0-beta.2

### DIFF
--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/nextjs-app-router/package.json
+++ b/examples/nextjs-app-router/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "next": "^15.5.15",
     "react": "19.0.0",
     "react-dom": "19.0.0"

--- a/examples/nextjs-ssr/package.json
+++ b/examples/nextjs-ssr/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "next": "15.1.7",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/nextjs-todo/package.json
+++ b/examples/nextjs-todo/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "next": "15.1.7",
     "react": "19.0.0",
     "react-dom": "19.0.0"

--- a/examples/reduxtagram/package.json
+++ b/examples/reduxtagram/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@types/react-transition-group": "^4.4.5",
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "nanoid": "^5.0.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/simple-todo/package.json
+++ b/examples/simple-todo/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/v7-concurrent/package.json
+++ b/examples/v7-concurrent/package.json
@@ -9,7 +9,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "easy-peasy": "^7.0.0-beta.1",
+    "easy-peasy": "^7.0.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/v7-concurrent/src/store/hooks.ts
+++ b/examples/v7-concurrent/src/store/hooks.ts
@@ -1,4 +1,4 @@
-import { createTypedHooks, useStoreRehydrated } from 'easy-peasy';
+import { createTypedHooks } from 'easy-peasy';
 
 import type { StoreModel } from './model';
 
@@ -7,9 +7,8 @@ export const {
   useStoreDispatch,
   useStoreState,
   useStore,
+  useStoreRehydrated,
   useStoreTransition,
   useStoreDeferredState,
   useStoreOptimistic,
 } = createTypedHooks<StoreModel>();
-
-export { useStoreRehydrated };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-peasy",
-  "version": "7.0.0-beta.1",
+  "version": "7.0.0-beta.2",
   "description": "Vegetarian friendly state for React",
   "license": "MIT",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- Bumps root package to **7.0.0-beta.2**.
- Points all examples at `easy-peasy@^7.0.0-beta.2`.
- Drops the `useStoreRehydrated` re-export shim in `examples/v7-concurrent/src/store/hooks.ts` (no longer needed now that beta.2 includes `useStoreRehydrated` in the `createTypedHooks` return type — fixed in #1036).

## Changes
- `package.json` — version bump.
- `examples/{kanban,nextjs-app-router,nextjs-ssr,nextjs-todo,reduxtagram,simple-todo,v7-concurrent}/package.json` — `easy-peasy` ^7.0.0-beta.1 → ^7.0.0-beta.2.
- `examples/v7-concurrent/src/store/hooks.ts` — fold `useStoreRehydrated` into the `createTypedHooks` destructure.

## Release steps after merge
1. Tag master commit as `v7.0.0-beta.2` and push the tag.
2. `npm publish --tag beta` from the tagged commit.
3. Example lockfiles will refresh on next `yarn install` once beta.2 is on npm.

Verified locally by swapping the local `index.d.ts` into `examples/v7-concurrent/node_modules/easy-peasy/` and running `yarn type-check` — passes.