### PR TITLE
chore(examples): refresh lockfiles for easy-peasy 7.0.0-beta.2

### DIFF
--- a/examples/kanban/yarn.lock
+++ b/examples/kanban/yarn.lock
@@ -1080,10 +1080,10 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/nextjs-app-router/yarn.lock
+++ b/examples/nextjs-app-router/yarn.lock
@@ -247,10 +247,10 @@ detect-libc@^2.1.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/nextjs-ssr/yarn.lock
+++ b/examples/nextjs-ssr/yarn.lock
@@ -234,10 +234,10 @@ detect-libc@^2.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/nextjs-todo/yarn.lock
+++ b/examples/nextjs-todo/yarn.lock
@@ -714,10 +714,10 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/reduxtagram/yarn.lock
+++ b/examples/reduxtagram/yarn.lock
@@ -937,10 +937,10 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/simple-todo/yarn.lock
+++ b/examples/simple-todo/yarn.lock
@@ -860,10 +860,10 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"

--- a/examples/v7-concurrent/yarn.lock
+++ b/examples/v7-concurrent/yarn.lock
@@ -554,10 +554,10 @@ debug@^4.1.0, debug@^4.3.1:
   dependencies:
     ms "^2.1.3"
 
-easy-peasy@^7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.1.tgz#2c56b178f501c54099809051cabe4568ac36060d"
-  integrity sha512-lLjMXCA7YIgC6Vb7EsWHPeWzRTByKbdZt1nPeIh4QTRhVv7JeUB2azya9DaG8QJ6WAKCkaFBrt4zfh6WpJt6jw==
+easy-peasy@^7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-7.0.0-beta.2.tgz#4f3c4e78b1e61c9bdc4c92acca64fbce36ffcefa"
+  integrity sha512-dZvok0QHLYKa/4ywfBcz+xiT7t5UxWzv80N8TdXKmMIyvnJaV0R08Utb4YpkiF83Tz0Re2BXzxDnz4sEeOu0mw==
   dependencies:
     fast-deep-equal "^3.1.3"
     immer "^11.1.4"


### PR DESCRIPTION
## Summary
Re-runs `yarn install` in each example that depends on `easy-peasy@^7.0.0-beta.2` so the lockfiles resolve to the freshly-published 7.0.0-beta.2 (instead of the stale 7.0.0-beta.1 entries left over from the release PR).

## Changes
Bumps `easy-peasy@^7.0.0-beta.X` resolution from `7.0.0-beta.1` to `7.0.0-beta.2` in:
- `examples/kanban/yarn.lock`
- `examples/nextjs-app-router/yarn.lock`
- `examples/nextjs-ssr/yarn.lock`
- `examples/nextjs-todo/yarn.lock`
- `examples/reduxtagram/yarn.lock`
- `examples/simple-todo/yarn.lock`
- `examples/v7-concurrent/yarn.lock`

No other dependencies changed. `examples/react-native-todo` is still on `^6.0.0` and was not touched.